### PR TITLE
feat: Auto-deploy develop to Azure dev environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,8 @@
 # Deploys updated Container App images to Azure.
 #
 # Triggers:
-#   - Push to `dev` branch → auto-deploys to dev environment
-#   - workflow_dispatch    → manual deploy to dev or prod (prod is manual-only)
+#   - workflow_run: after Publish Docker Images completes on develop → auto-deploys to dev
+#   - workflow_dispatch: manual deploy to dev or prod (prod is manual-only)
 #
 # Required secrets:
 #   AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
@@ -12,9 +12,12 @@
 name: Deploy to Azure
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Publish Docker Images"]
+    types:
+      - completed
     branches:
-      - dev
+      - develop
   workflow_dispatch:
     inputs:
       environment:
@@ -38,8 +41,9 @@ jobs:
   deploy:
     name: Update Container App images
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     env:
-      DEPLOY_ENV: ${{ github.event_name == 'push' && 'dev' || inputs.environment }}
+      DEPLOY_ENV: ${{ github.event_name == 'workflow_run' && 'dev' || inputs.environment }}
 
     steps:
       - name: Resolve image coordinates
@@ -47,16 +51,27 @@ jobs:
         run: |
           SHA="${{ inputs.sha }}"
           if [[ -z "$SHA" ]]; then
-            SHA="${{ github.sha }}"
+            if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+              SHA="${{ github.event.workflow_run.head_sha }}"
+            else
+              SHA="${{ github.sha }}"
+            fi
           fi
           OWNER="${{ inputs.owner }}"
           if [[ -z "$OWNER" ]]; then
             OWNER="${{ github.repository_owner }}"
           fi
           OWNER="${OWNER,,}"
+          # Dev images use develop- prefix; prod images use bare SHA
+          if [[ "${{ env.DEPLOY_ENV }}" == "dev" ]]; then
+            TAG="develop-${SHA}"
+          else
+            TAG="${SHA}"
+          fi
           echo "sha=$SHA" >> $GITHUB_OUTPUT
           echo "owner=$OWNER" >> $GITHUB_OUTPUT
-          echo "Deploying SHA: $SHA to ${{ env.DEPLOY_ENV }} (owner: $OWNER)"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Deploying tag: $TAG to ${{ env.DEPLOY_ENV }} (owner: $OWNER)"
 
       - name: Azure login
         run: |
@@ -71,11 +86,11 @@ jobs:
           az containerapp update \
             --name ca-arachne-gateway-${{ env.DEPLOY_ENV }} \
             --resource-group rg-arachne-${{ env.DEPLOY_ENV }} \
-            --image ghcr.io/${{ steps.coords.outputs.owner }}/arachne-gateway:${{ steps.coords.outputs.sha }}
+            --image ghcr.io/${{ steps.coords.outputs.owner }}/arachne-gateway:${{ steps.coords.outputs.tag }}
 
       - name: Update portal image
         run: |
           az containerapp update \
             --name ca-arachne-portal-${{ env.DEPLOY_ENV }} \
             --resource-group rg-arachne-${{ env.DEPLOY_ENV }} \
-            --image ghcr.io/${{ steps.coords.outputs.owner }}/arachne-portal:${{ steps.coords.outputs.sha }}
+            --image ghcr.io/${{ steps.coords.outputs.owner }}/arachne-portal:${{ steps.coords.outputs.tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
 
 jobs:
   publish:
@@ -16,9 +17,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set lowercase owner
-        id: lower
-        run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+      - name: Set image coordinates
+        id: coords
+        run: |
+          echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          if [[ "${{ github.ref_name }}" == "develop" ]]; then
+            echo "prefix=develop-" >> $GITHUB_OUTPUT
+          else
+            echo "prefix=" >> $GITHUB_OUTPUT
+          fi
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -34,8 +41,8 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ steps.lower.outputs.owner }}/arachne-gateway:latest
-            ghcr.io/${{ steps.lower.outputs.owner }}/arachne-gateway:${{ github.sha }}
+            ghcr.io/${{ steps.coords.outputs.owner }}/arachne-gateway:${{ steps.coords.outputs.prefix }}latest
+            ghcr.io/${{ steps.coords.outputs.owner }}/arachne-gateway:${{ steps.coords.outputs.prefix }}${{ github.sha }}
 
       - name: Build and push portal image
         uses: docker/build-push-action@v5
@@ -44,8 +51,8 @@ jobs:
           file: ./Dockerfile.portal
           push: true
           tags: |
-            ghcr.io/${{ steps.lower.outputs.owner }}/arachne-portal:latest
-            ghcr.io/${{ steps.lower.outputs.owner }}/arachne-portal:${{ github.sha }}
+            ghcr.io/${{ steps.coords.outputs.owner }}/arachne-portal:${{ steps.coords.outputs.prefix }}latest
+            ghcr.io/${{ steps.coords.outputs.owner }}/arachne-portal:${{ steps.coords.outputs.prefix }}${{ github.sha }}
 
       - name: Build and push smoke runner image
         uses: docker/build-push-action@v5
@@ -54,8 +61,8 @@ jobs:
           file: ./Dockerfile.smoke-runner
           push: true
           tags: |
-            ghcr.io/${{ steps.lower.outputs.owner }}/arachne-smoke-runner:latest
-            ghcr.io/${{ steps.lower.outputs.owner }}/arachne-smoke-runner:${{ github.sha }}
+            ghcr.io/${{ steps.coords.outputs.owner }}/arachne-smoke-runner:${{ steps.coords.outputs.prefix }}latest
+            ghcr.io/${{ steps.coords.outputs.owner }}/arachne-smoke-runner:${{ steps.coords.outputs.prefix }}${{ github.sha }}
 
       # Note: After first publish, set package visibility to public in GitHub:
       # Settings → Packages → arachne-gateway / arachne-portal / arachne-smoke-runner → Change visibility → Public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Claude operates as **Operator** — a team coordinator that dispatches work to s
 | Cipher | Pentester & Attack Stories | Explore / general-purpose |
 | Agent Smith | Code Review & Quality | Explore / general-purpose |
 | Merovingian | System Impact Analyst | Explore |
+| Link | Infrastructure Engineer | general-purpose |
 
 Agent prompt files are in `~/.claude/projects/-Users-michaelbrown-projects-loom/memory/agents/{name}/prompt.md`.
 

--- a/Dockerfile.portal
+++ b/Dockerfile.portal
@@ -27,11 +27,14 @@ RUN npm run build
 # Apps Envoy ingress Upgrade: h2c negotiation succeeds instead of returning 426.
 FROM nginx:stable-alpine
 
-# Copy custom nginx config
-COPY nginx.portal.conf /etc/nginx/conf.d/default.conf
+# Copy nginx config as template (envsubst processes on startup)
+COPY nginx.portal.conf /etc/nginx/templates/default.conf.template
 
 # Copy built static files
 COPY --from=builder /app/portal/dist /usr/share/nginx/html
+
+# Default gateway URL (overridden per environment)
+ENV GATEWAY_URL=https://ca-arachne-gateway-prod.happysea-1e8f1a10.centralus.azurecontainerapps.io
 
 # Expose HTTP port
 EXPOSE 80

--- a/nginx.portal.conf
+++ b/nginx.portal.conf
@@ -5,10 +5,10 @@ server {
 
     # Proxy API requests to gateway service
     location /v1 {
-        proxy_pass https://ca-arachne-gateway-prod.happysea-1e8f1a10.centralus.azurecontainerapps.io;
+        proxy_pass ${GATEWAY_URL};
         proxy_http_version 1.1;
         proxy_ssl_server_name on;
-        proxy_set_header Host ca-arachne-gateway-prod.happysea-1e8f1a10.centralus.azurecontainerapps.io;
+        proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/terraform/modules/container_apps/main.tf
+++ b/terraform/modules/container_apps/main.tf
@@ -151,6 +151,11 @@ resource "azurerm_container_app" "portal" {
       image  = var.portal_image
       cpu    = 0.25
       memory = "0.5Gi"
+
+      env {
+        name  = "GATEWAY_URL"
+        value = "https://${azurerm_container_app.gateway.ingress[0].fqdn}"
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- **publish.yml**: Build container images on `develop` branch with `develop-` tag prefix (e.g., `develop-latest`, `develop-abc123`)
- **deploy.yml**: Chain to publish via `workflow_run` trigger — auto-deploys to Azure dev when publish succeeds on develop. Prod remains manual-only.
- **nginx.portal.conf**: Template gateway URL via `envsubst` instead of hardcoding prod gateway URL
- **Dockerfile.portal**: Use nginx's built-in `/etc/nginx/templates/` directory for automatic envsubst processing
- **Terraform**: Add `GATEWAY_URL` env var to portal container app, pointing to gateway CA's FQDN
- **Team**: Add Link (Infrastructure Engineer) to team roster

## Image tagging strategy
| Branch | Tags |
|--------|------|
| `main` | `latest`, `{sha}` |
| `develop` | `develop-latest`, `develop-{sha}` |

## Deploy flow
```
develop push → publish.yml (build images) → deploy.yml (workflow_run) → az containerapp update (dev)
```

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Push to develop triggers publish workflow
- [ ] GHCR shows `develop-latest` and `develop-{sha}` tags
- [ ] Deploy workflow triggers after publish completes
- [ ] Dev portal proxies to dev gateway (not prod)
- [ ] Manual workflow_dispatch still works for prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)