### PR TITLE
feat: API key expiry and rotation (#112)

### DIFF
--- a/docs/system_specs/observability_architecture.md
+++ b/docs/system_specs/observability_architecture.md
@@ -1,0 +1,1035 @@
+# Observability Architecture
+
+**Status:** Draft
+**Author:** Arachne Team
+**Last Updated:** 2026-03-16
+
+## 1. Overview
+
+Arachne's observability architecture replaces the current synchronous, in-process trace recording pipeline with an event-driven system built on three pillars:
+
+1. **Structured lifecycle events** emitted from the gateway hot path via a queue-agnostic `EventBus` interface.
+2. **Asynchronous worker processes** that consume events, encrypt sensitive payloads, and write to both TimescaleDB (time-series analytics) and PostgreSQL (composite Trace rows for tenant dashboards).
+3. **Two-tier caching** (in-process L1 + Redis L2) with pub/sub invalidation across gateway replicas.
+
+The architecture preserves the current < 20ms gateway overhead target by moving all write-path work (encryption, persistence, aggregation) off the request thread. It supports a single-binary "desktop mode" for local development and solo deployments, where all components run in-process against SQLite.
+
+---
+
+## 2. Architecture Diagram
+
+```
+                          Tenant App / CLI
+                               |
+                     POST /v1/chat/completions
+                               |
+                               v
+               +-------------------------------+
+               |        Gateway Process        |
+               |  (Fastify + EventBus.emit())  |
+               |                               |
+               |  L1 Cache (Map, 30s TTL)      |
+               +---------|---------------------+
+                         |           |
+               emit()    |           | get/set
+                         v           v
+               +---------+   +-------------+
+               |  Queue   |   |    Redis    |
+               | (agnostic|   | L2 Cache +  |
+               |  adapter)|   | pub/sub     |
+               +---------+   +-------------+
+                    |                |
+                    v                | invalidation
+          +------------------+      | broadcast
+          |  Worker Process  |<-----+
+          |  (src/worker.ts) |
+          |                  |
+          |  - Decrypt/Encrypt
+          |  - Assemble Trace
+          |  - Write points
+          +--------+---------+
+                   |
+          +--------+---------+
+          |                  |
+          v                  v
+  +---------------+  +---------------+
+  | TimescaleDB   |  | PostgreSQL    |
+  | (hypertable:  |  | (traces table |
+  |  events,      |  |  for tenant   |
+  |  continuous   |  |  dashboards)  |
+  |  aggregates)  |  |               |
+  +-------+-------+  +-------+-------+
+          |                  |
+          v                  v
+  +---------------+  +---------------+
+  |   Grafana     |  |  Recharts     |
+  | (operator     |  | (tenant       |
+  |  dashboards)  |  |  dashboards)  |
+  +---------------+  +---------------+
+```
+
+**Desktop mode** collapses this to a single process: `InMemoryEventBus` replaces the queue, the worker logic runs inline, and SQLite replaces both TimescaleDB and PostgreSQL.
+
+---
+
+## 3. Request Envelope
+
+Every event emitted during a request carries a correlation envelope that links it to the originating request, tenant, and agent.
+
+```typescript
+/**
+ * Correlation context attached to every GatewayEvent.
+ * The worker uses these fields to group events into composite Trace rows
+ * and to route data to the correct tenant partition.
+ */
+interface RequestEnvelope {
+  /** UUIDv4 generated at request entry. Correlates all events for one request. */
+  requestId: string;
+
+  /** Tenant resolved from the API key. Present on all events after auth. */
+  tenantId: string;
+
+  /** Agent bound to the API key, if any. */
+  agentId?: string;
+
+  /** End-user identity from X-Arachne-Principal header. */
+  principalId?: string;
+
+  /** Deployment slot ID, if the request targets a deployment. */
+  deploymentId?: string;
+
+  /** Unix epoch ms when the gateway received the request. */
+  timestamp: number;
+}
+```
+
+The `requestId` is generated once in the request handler and threaded through all downstream calls. It is returned to the caller via the `X-Arachne-Request-ID` response header for client-side correlation.
+
+---
+
+## 4. Event Taxonomy
+
+Events are organized into categories. Each event has a **visibility** classification:
+
+- **Internal**: Operator-only (Grafana dashboards, debugging).
+- **Tenant-visible**: Exposed in tenant analytics and Recharts dashboards.
+- **Both**: Available to operators and tenants.
+
+### 4.1 Request Lifecycle
+
+| Event | Visibility | Fires When | Key Fields | Enables |
+|-------|-----------|------------|------------|---------|
+| `request.received` | Both | Gateway receives the HTTP request | `method`, `path`, `model`, `stream` | Request rate metrics, start of latency measurement |
+| `request.completed` | Both | Response fully sent to client | `statusCode`, `latencyMs`, `ttfbMs`, `gatewayOverheadMs` | End-to-end latency, overhead tracking |
+| `request.failed` | Both | Unhandled error in the request pipeline | `error`, `statusCode` | Error rate, error classification |
+
+### 4.2 Authentication
+
+| Event | Visibility | Fires When | Key Fields | Enables |
+|-------|-----------|------------|------------|---------|
+| `auth.resolved` | Internal | API key successfully resolved to TenantContext | `cacheHit`, `resolutionMs` | Cache hit ratio, auth latency |
+| `auth.failed` | Internal | API key missing, invalid, or tenant inactive | `reason`, `keyHashPrefix` | Security alerting, brute-force detection |
+
+### 4.3 Conversation Memory
+
+| Event | Visibility | Fires When | Key Fields | Enables |
+|-------|-----------|------------|------------|---------|
+| `conversation.resolved` | Tenant-visible | Conversation found or created | `conversationId`, `isNew`, `partitionId` | Conversation lifecycle tracking |
+| `conversation.context_loaded` | Internal | History + snapshots loaded from DB | `messageCount`, `tokenEstimate`, `snapshotId`, `loadMs` | Memory subsystem health |
+| `conversation.summarized` | Tenant-visible | Token budget exceeded, summary generated | `originalTokens`, `summaryTokens`, `summaryModel`, `summarizeMs` | Summary frequency, token savings |
+
+### 4.4 RAG Retrieval
+
+| Event | Visibility | Fires When | Key Fields | Enables |
+|-------|-----------|------------|------------|---------|
+| `rag.started` | Both | RAG pipeline begins for a request | `knowledgeBaseId` | RAG usage tracking |
+| `rag.embedding.completed` | Internal | Query embedding generated | `embeddingMs`, `embeddingModel` | Embedding latency monitoring |
+| `rag.search.completed` | Internal | Vector search returns chunks | `vectorSearchMs`, `chunkCount`, `topSimilarity`, `avgSimilarity` | Retrieval quality metrics |
+| `rag.injection.completed` | Both | Chunks injected into prompt | `contextTokensAdded`, `ragOverheadTokens` | Token overhead from RAG |
+| `rag.failed` | Both | Any RAG stage failed | `stage`, `error`, `fallbackToNoRag` | RAG reliability, fallback rate |
+
+### 4.5 Agent Application
+
+| Event | Visibility | Fires When | Key Fields | Enables |
+|-------|-----------|------------|------------|---------|
+| `agent.config_applied` | Internal | System prompt and skills merged into request | `mergePolicy`, `skillCount`, `mcpEndpointCount` | Agent config audit trail |
+
+### 4.6 Provider Proxy
+
+| Event | Visibility | Fires When | Key Fields | Enables |
+|-------|-----------|------------|------------|---------|
+| `provider.request.sent` | Internal | Upstream fetch initiated | `provider`, `model`, `baseUrl` | Provider routing audit |
+| `provider.response.completed` | Both | Upstream response fully received | `statusCode`, `upstreamLatencyMs`, `promptTokens`, `completionTokens`, `totalTokens`, `estimatedCostUsd` | Provider latency, token usage, cost tracking |
+| `provider.response.error` | Both | Upstream returned >= 400 | `statusCode`, `errorCode`, `errorMessage`, `provider` | Provider error rate, error classification |
+
+### 4.7 Streaming
+
+| Event | Visibility | Fires When | Key Fields | Enables |
+|-------|-----------|------------|------------|---------|
+| `stream.first_byte` | Both | First SSE chunk forwarded to client | `ttfbMs` | Time-to-first-byte tracking |
+| `stream.completed` | Internal | SSE stream ends, `[DONE]` received | `totalChunks`, `contentLength`, `streamDurationMs` | Stream health monitoring |
+
+### 4.8 MCP Tool Execution
+
+| Event | Visibility | Fires When | Key Fields | Enables |
+|-------|-----------|------------|------------|---------|
+| `mcp.round_trip.started` | Both | Tool calls detected in provider response | `toolCallCount` | MCP usage tracking |
+| `mcp.tool.called` | Both | Individual MCP endpoint invoked | `toolName`, `endpointUrl`, `callMs`, `statusCode` | Per-tool latency and error tracking |
+| `mcp.round_trip.completed` | Both | All tool results sent back to provider | `totalMs`, `toolCallCount` | Round-trip overhead |
+
+### 4.9 Cache Operations
+
+| Event | Visibility | Fires When | Key Fields | Enables |
+|-------|-----------|------------|------------|---------|
+| `cache.hit` | Internal | L1 or L2 cache returns a value | `namespace`, `layer` (`l1` or `l2`), `key` | Cache hit ratio per layer |
+| `cache.miss` | Internal | Both L1 and L2 miss, falling through to DB | `namespace`, `key`, `loadMs` | Cache miss rate, cold-start impact |
+| `cache.eviction` | Internal | Entry evicted from L1 or L2 | `namespace`, `layer`, `reason` (`ttl`, `capacity`, `invalidation`) | Cache pressure monitoring |
+
+### 4.10 Gateway Health
+
+| Event | Visibility | Fires When | Key Fields | Enables |
+|-------|-----------|------------|------------|---------|
+| `gateway.queue.depth` | Internal | Periodic (every 10s) | `depth`, `oldestEventAge` | Queue backpressure alerting |
+| `gateway.process.stats` | Internal | Periodic (every 30s) | `heapUsedMb`, `rss`, `eventLoopDelayMs`, `activeRequests` | Process health, memory leak detection |
+
+---
+
+## 5. EventBus Interface
+
+The `EventBus` is the core abstraction that decouples event producers (gateway) from consumers (worker). Implementations must be swappable without changing application code.
+
+### 5.1 Core Types
+
+```typescript
+/** Base event shape. All lifecycle events extend this. */
+interface GatewayEvent {
+  /** Event type from the taxonomy (e.g. 'request.received'). */
+  type: string;
+
+  /** Correlation ID linking all events for one request. */
+  requestId: string;
+
+  /** Tenant that owns this request. Absent only for pre-auth events. */
+  tenantId?: string;
+
+  /** Unix epoch ms when the event was created. */
+  timestamp: number;
+
+  /** Arbitrary payload fields specific to the event type. */
+  [key: string]: unknown;
+}
+
+/** Consumer callback signature. */
+type EventHandler = (event: GatewayEvent) => Promise<void> | void;
+
+/** Queue-agnostic event bus contract. */
+interface EventBus {
+  /**
+   * Emit an event. In production this publishes to the message queue.
+   * In desktop mode it dispatches to in-process handlers.
+   * Must never throw — failures are logged and swallowed.
+   */
+  emit(event: GatewayEvent): void;
+
+  /**
+   * Register a handler for one or more event types.
+   * Used by the worker process to subscribe to events.
+   * Supports glob patterns: 'rag.*' matches all RAG events.
+   */
+  on(pattern: string, handler: EventHandler): void;
+
+  /**
+   * Graceful shutdown: flush pending events, close connections.
+   */
+  shutdown(): Promise<void>;
+}
+```
+
+### 5.2 Production Implementation (Queue-backed)
+
+```typescript
+/**
+ * Publishes events to an external message queue.
+ * The queue technology is injected via QueueAdapter, keeping
+ * the EventBus itself queue-agnostic.
+ */
+class QueueEventBus implements EventBus {
+  private adapter: QueueAdapter;
+  private buffer: GatewayEvent[] = [];
+  private flushTimer: ReturnType<typeof setInterval>;
+
+  constructor(adapter: QueueAdapter) {
+    this.adapter = adapter;
+    // Micro-batch: flush every 50ms or 50 events to reduce per-event overhead.
+    this.flushTimer = setInterval(() => this.flush(), 50);
+    this.flushTimer.unref();
+  }
+
+  emit(event: GatewayEvent): void {
+    this.buffer.push(event);
+    if (this.buffer.length >= 50) {
+      void this.flush();
+    }
+  }
+
+  on(pattern: string, handler: EventHandler): void {
+    this.adapter.subscribe(pattern, handler);
+  }
+
+  private async flush(): Promise<void> {
+    if (this.buffer.length === 0) return;
+    const batch = this.buffer.splice(0);
+    try {
+      await this.adapter.publishBatch(batch);
+    } catch (err) {
+      console.error('[eventbus] flush failed:', err);
+      // Events are lost — acceptable for observability data.
+      // A dead-letter mechanism in the adapter can reduce loss.
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    clearInterval(this.flushTimer);
+    await this.flush();
+    await this.adapter.close();
+  }
+}
+```
+
+### 5.3 Queue Adapter Contract
+
+```typescript
+/**
+ * Thin adapter over the actual queue technology.
+ * Swap this to switch from one queue to another.
+ */
+interface QueueAdapter {
+  publishBatch(events: GatewayEvent[]): Promise<void>;
+  subscribe(pattern: string, handler: EventHandler): void;
+  close(): Promise<void>;
+}
+```
+
+### 5.4 Usage in the Request Handler
+
+```typescript
+// src/index.ts — simplified excerpt showing EventBus integration
+
+const eventBus: EventBus = createEventBus(); // factory resolves impl from config
+
+fastify.post('/v1/chat/completions', async (request, reply) => {
+  const requestId = randomUUID();
+  const startMs = Date.now();
+
+  eventBus.emit({
+    type: 'request.received',
+    requestId,
+    tenantId: request.tenant?.tenantId,
+    timestamp: startMs,
+    model: (request.body as any)?.model,
+    stream: (request.body as any)?.stream ?? false,
+  });
+
+  // ... auth, conversation, RAG, agent application ...
+  // Each subsystem emits its own events using the same requestId.
+
+  const upstreamStartMs = Date.now();
+  eventBus.emit({
+    type: 'provider.request.sent',
+    requestId,
+    tenantId: request.tenant!.tenantId,
+    timestamp: upstreamStartMs,
+    provider: provider.name,
+    model: effectiveBody.model,
+  });
+
+  const response = await provider.proxy(proxyReq);
+
+  eventBus.emit({
+    type: 'provider.response.completed',
+    requestId,
+    tenantId: request.tenant!.tenantId,
+    timestamp: Date.now(),
+    statusCode: response.status,
+    upstreamLatencyMs: Date.now() - upstreamStartMs,
+    promptTokens: response.body?.usage?.prompt_tokens,
+    completionTokens: response.body?.usage?.completion_tokens,
+    totalTokens: response.body?.usage?.total_tokens,
+  });
+
+  // ... send response ...
+
+  eventBus.emit({
+    type: 'request.completed',
+    requestId,
+    tenantId: request.tenant!.tenantId,
+    timestamp: Date.now(),
+    statusCode: response.status,
+    latencyMs: Date.now() - startMs,
+    gatewayOverheadMs: upstreamStartMs - startMs,
+  });
+});
+```
+
+---
+
+## 6. Worker Container
+
+### 6.1 Architecture
+
+The worker runs from the same codebase as the gateway but with a different entrypoint (`src/worker.ts`). It shares domain entities, encryption utilities, and TypeScript types. It does not run Fastify or serve HTTP traffic.
+
+```
+src/
+├── worker.ts              # Entrypoint: connect to queue, register handlers
+├── worker/
+│   ├── TraceAssembler.ts  # Groups events by requestId, builds Trace entity
+│   ├── TimeSeriesWriter.ts # Writes individual event points to TimescaleDB
+│   └── HealthReporter.ts  # Emits gateway.queue.depth and process stats
+```
+
+### 6.2 Responsibilities
+
+1. **Consume events** from the message queue via the `QueueAdapter.subscribe()` interface.
+2. **Encrypt sensitive payloads** — request/response bodies are encrypted with per-tenant AES-256-GCM keys, moved off the gateway hot path.
+3. **Assemble composite Traces** — the `TraceAssembler` collects events for a `requestId` with a 30-second window, then writes a single `Trace` row to PostgreSQL (preserving backward compatibility with existing tenant dashboards).
+4. **Write time-series points** — each event is independently written to the TimescaleDB `gateway_events` hypertable for fine-grained operator analytics.
+5. **Cost estimation** — the worker computes `estimated_cost_usd` from token counts and model pricing, replacing the inline SQL CASE expression.
+
+### 6.3 Trace Assembly
+
+```typescript
+class TraceAssembler {
+  // In-memory map of requestId -> collected events.
+  // Entries are flushed after 30s or when request.completed is received.
+  private pending = new Map<string, { events: GatewayEvent[]; timer: NodeJS.Timeout }>();
+
+  onEvent(event: GatewayEvent): void {
+    const entry = this.pending.get(event.requestId) ?? this.createEntry(event.requestId);
+    entry.events.push(event);
+
+    if (event.type === 'request.completed' || event.type === 'request.failed') {
+      this.assemble(event.requestId);
+    }
+  }
+
+  private assemble(requestId: string): void {
+    const entry = this.pending.get(requestId);
+    if (!entry) return;
+    clearTimeout(entry.timer);
+    this.pending.delete(requestId);
+
+    const events = entry.events;
+    const received = events.find(e => e.type === 'request.received');
+    const completed = events.find(e => e.type === 'request.completed');
+    const providerResp = events.find(e => e.type === 'provider.response.completed');
+
+    // Build Trace entity from composed fields...
+    // Encrypt request/response bodies using per-tenant key...
+    // Persist to PostgreSQL traces table...
+  }
+}
+```
+
+### 6.4 Scaling
+
+Workers scale independently of gateway replicas. Each worker instance joins the same consumer group, so the queue distributes events across workers. No coordination is needed between workers because events for the same `requestId` are routed to the same partition (using `requestId` as the partition key, or `tenantId` for tenant-level ordering).
+
+### 6.5 Startup
+
+```bash
+# Production: gateway and worker as separate processes
+npm run start:gateway    # src/index.ts
+npm run start:worker     # src/worker.ts
+
+# Development: single process (desktop mode, see Section 10)
+npm run dev              # runs both inline
+```
+
+---
+
+## 7. TimescaleDB Integration
+
+### 7.1 Rationale
+
+The current `traces` table uses manual monthly partitions (`traces_YYYY_MM`) and hand-rolled epoch-floor bucketing in `analytics.ts`. TimescaleDB provides:
+
+- Automatic time-based partitioning via hypertables (replaces manual `Partition` entity management).
+- Native `time_bucket()` function (replaces `to_timestamp(floor(extract(epoch from created_at) / seconds) * seconds)`).
+- Continuous aggregates with automatic refresh (replaces on-the-fly aggregation queries).
+- Built-in compression and retention policies.
+
+### 7.2 Hypertable: `gateway_events`
+
+This is the new fine-grained event store, written to by the `TimeSeriesWriter`.
+
+```sql
+-- Migration: create gateway_events hypertable
+CREATE TABLE gateway_events (
+  time          TIMESTAMPTZ    NOT NULL,
+  request_id    UUID           NOT NULL,
+  tenant_id     UUID           NOT NULL,
+  agent_id      UUID,
+  principal_id  VARCHAR(255),
+  deployment_id UUID,
+  event_type    VARCHAR(64)    NOT NULL,
+  payload       JSONB          NOT NULL DEFAULT '{}'
+);
+
+-- Convert to hypertable with 1-hour chunks
+SELECT create_hypertable('gateway_events', 'time',
+  chunk_time_interval => INTERVAL '1 hour'
+);
+
+-- Indexes for common query patterns
+CREATE INDEX idx_events_tenant_time ON gateway_events (tenant_id, time DESC);
+CREATE INDEX idx_events_request_id  ON gateway_events (request_id);
+CREATE INDEX idx_events_type_time   ON gateway_events (event_type, time DESC);
+```
+
+### 7.3 Continuous Aggregates
+
+Replace the per-query aggregations in `analytics.ts` with pre-computed rollups.
+
+#### Hourly Request Metrics
+
+```sql
+CREATE MATERIALIZED VIEW hourly_request_metrics
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket('1 hour', time)                           AS bucket,
+  tenant_id,
+  (payload->>'model')::text                             AS model,
+  (payload->>'provider')::text                          AS provider,
+  COUNT(*)                                              AS request_count,
+  AVG((payload->>'latencyMs')::float)                   AS avg_latency_ms,
+  percentile_agg((payload->>'latencyMs')::double precision) AS latency_pct,
+  SUM((payload->>'totalTokens')::bigint)                AS total_tokens,
+  SUM((payload->>'promptTokens')::bigint)               AS prompt_tokens,
+  SUM((payload->>'completionTokens')::bigint)           AS completion_tokens,
+  SUM((payload->>'estimatedCostUsd')::numeric)          AS estimated_cost_usd,
+  COUNT(*) FILTER (
+    WHERE (payload->>'statusCode')::int >= 400
+  )                                                     AS error_count,
+  AVG((payload->>'gatewayOverheadMs')::float)           AS avg_overhead_ms,
+  AVG((payload->>'ttfbMs')::float)                      AS avg_ttfb_ms
+FROM gateway_events
+WHERE event_type = 'request.completed'
+GROUP BY bucket, tenant_id, model, provider
+WITH NO DATA;
+
+-- Refresh policy: update every 10 minutes, covering last 2 hours
+SELECT add_continuous_aggregate_policy('hourly_request_metrics',
+  start_offset    => INTERVAL '2 hours',
+  end_offset      => INTERVAL '10 minutes',
+  schedule_interval => INTERVAL '10 minutes'
+);
+```
+
+#### Daily Rollup
+
+```sql
+CREATE MATERIALIZED VIEW daily_request_metrics
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket('1 day', bucket)    AS bucket,
+  tenant_id,
+  model,
+  provider,
+  SUM(request_count)              AS request_count,
+  -- Re-aggregate from hourly; weighted average for latency
+  SUM(avg_latency_ms * request_count) / NULLIF(SUM(request_count), 0) AS avg_latency_ms,
+  SUM(total_tokens)               AS total_tokens,
+  SUM(prompt_tokens)              AS prompt_tokens,
+  SUM(completion_tokens)          AS completion_tokens,
+  SUM(estimated_cost_usd)         AS estimated_cost_usd,
+  SUM(error_count)                AS error_count,
+  SUM(avg_overhead_ms * request_count) / NULLIF(SUM(request_count), 0) AS avg_overhead_ms,
+  SUM(avg_ttfb_ms * request_count) / NULLIF(SUM(request_count), 0)    AS avg_ttfb_ms
+FROM hourly_request_metrics
+GROUP BY bucket, tenant_id, model, provider
+WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('daily_request_metrics',
+  start_offset    => INTERVAL '2 days',
+  end_offset      => INTERVAL '1 hour',
+  schedule_interval => INTERVAL '1 hour'
+);
+```
+
+### 7.4 Compression Policy
+
+```sql
+-- Compress chunks older than 7 days (events are rarely queried at raw granularity after that)
+ALTER TABLE gateway_events SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'tenant_id',
+  timescaledb.compress_orderby = 'time DESC'
+);
+
+SELECT add_compression_policy('gateway_events', INTERVAL '7 days');
+```
+
+### 7.5 Retention Policy
+
+```sql
+-- Drop raw event chunks older than 90 days.
+-- Continuous aggregates (hourly/daily) are retained independently.
+SELECT add_retention_policy('gateway_events', INTERVAL '90 days');
+
+-- Keep hourly aggregates for 1 year.
+SELECT add_retention_policy('hourly_request_metrics', INTERVAL '365 days');
+
+-- Keep daily aggregates indefinitely (low volume).
+```
+
+### 7.6 Query Migration Map
+
+How existing `analytics.ts` query families map to the new schema:
+
+| Current Pattern | Current Source | New Source |
+|-----------------|---------------|-----------|
+| `getAnalyticsSummary()` | Raw SQL on `traces` with `percentile_cont` | `SELECT` from `hourly_request_metrics` with `SUM`/`AVG` over window |
+| `getTimeseriesMetrics()` | `to_timestamp(floor(extract(epoch...) / seconds) * seconds)` | `SELECT` from `hourly_request_metrics` directly (hourly buckets) or `time_bucket()` on raw events for sub-hour |
+| `getModelBreakdown()` | `GROUP BY model` on `traces` | `SELECT` from `hourly_request_metrics` grouped by `model` |
+| Subtenant rollup | `WITH RECURSIVE subtenant_tree` CTE | Same CTE joined against `hourly_request_metrics.tenant_id` |
+| Cost estimation | Inline `CASE WHEN model ILIKE '%gpt-3.5%'` | Pre-computed by worker, stored in `estimated_cost_usd` field |
+
+**Backward compatibility:** The existing `traces` table continues to serve the tenant Recharts dashboards during the transition. The worker writes to both `gateway_events` (new) and `traces` (legacy) until all analytics queries are migrated.
+
+---
+
+## 8. Redis Caching Architecture
+
+### 8.1 Two-Tier Cache Design
+
+```
+  Request
+    |
+    v
+ +--------+    miss    +--------+    miss    +--------+
+ |   L1   | ---------> |   L2   | ---------> |   DB   |
+ | (Map)  |            | (Redis)|            |        |
+ | 30s TTL|            | ns TTL |            |        |
+ +--------+            +--------+            +--------+
+    ^                      |
+    |    pub/sub invalidate |
+    +----------------------+
+```
+
+### 8.2 Cache Service Interface
+
+```typescript
+interface CacheService {
+  get<T>(namespace: CacheNamespace, key: string): Promise<T | undefined>;
+  set<T>(namespace: CacheNamespace, key: string, value: T): Promise<void>;
+  invalidate(namespace: CacheNamespace, key: string): Promise<void>;
+}
+
+type CacheNamespace = 'tenant_auth' | 'provider_config' | 'agent_config';
+```
+
+### 8.3 L1: In-Process Cache
+
+- **Implementation:** `Map<string, { value: unknown; expiresAt: number }>` with lazy eviction on access.
+- **Capacity:** 100 entries per namespace (300 total). Evicts oldest on overflow.
+- **TTL:** 30 seconds. Short enough that invalidation propagation delay is acceptable.
+- **Scope:** Local to each gateway process. Not shared across replicas.
+
+This replaces the current `LRUCache` in `src/auth.ts` (1,000 entries, no TTL).
+
+### 8.4 L2: Redis
+
+- **Client:** `ioredis` with connection pooling and automatic reconnection.
+- **Key format:** `arachne:cache:{namespace}:{id}`
+  - Example: `arachne:cache:tenant_auth:sha256_abc123def...`
+- **TTL per namespace:**
+
+| Namespace | TTL | Rationale |
+|-----------|-----|-----------|
+| `tenant_auth` | 5 min | Balance between DB load reduction and key revocation latency |
+| `provider_config` | 10 min | Provider configs change infrequently |
+| `agent_config` | 5 min | Agent updates should propagate within minutes |
+
+- **Serialization:** `JSON.stringify` / `JSON.parse`. Cache values are plain objects (no class instances).
+
+### 8.5 Invalidation via Pub/Sub
+
+When a cached entity is mutated (e.g., API key revoked, agent config updated), the service that performed the mutation publishes an invalidation message:
+
+```typescript
+// Channel: arachne:cache:invalidate
+// Message format:
+interface CacheInvalidation {
+  namespace: CacheNamespace;
+  key: string;        // specific key, or '*' for namespace-wide flush
+  tenantId?: string;  // for tenant-scoped invalidation
+}
+```
+
+All gateway replicas subscribe to `arachne:cache:invalidate` and clear matching L1 entries on receipt. Redis L2 entries are deleted directly by the publisher.
+
+```typescript
+// Publisher side (e.g., in PortalService after revoking a key)
+await cacheService.invalidate('tenant_auth', keyHash);
+// Under the hood:
+//   1. DEL arachne:cache:tenant_auth:{keyHash} from Redis
+//   2. PUBLISH arachne:cache:invalidate { namespace: 'tenant_auth', key: keyHash }
+
+// Subscriber side (each gateway process, on startup)
+redis.subscribe('arachne:cache:invalidate');
+redis.on('message', (channel, msg) => {
+  const inv = JSON.parse(msg) as CacheInvalidation;
+  l1Cache.delete(inv.namespace, inv.key);
+});
+```
+
+### 8.6 Graceful Degradation
+
+If Redis is unreachable:
+- L1 continues to serve cached data until TTL expiry.
+- Cache misses fall through directly to the database.
+- Invalidation messages are lost — L1 entries expire naturally via TTL (30s worst case).
+- The gateway logs warnings but does not fail requests.
+
+---
+
+## 9. Grafana Operator Dashboards
+
+Grafana connects directly to TimescaleDB as a PostgreSQL data source. Dashboards are provisioned as JSON and version-controlled in `infra/grafana/dashboards/`.
+
+### 9.1 Dashboard: Gateway Overview
+
+| Panel | Query Source | Visualization |
+|-------|-------------|---------------|
+| Request Rate (RPS) by model | `hourly_request_metrics` | Time series, stacked by model |
+| P50/P95/P99 Latency | `gateway_events` with `percentile_cont` | Histogram + time series overlay |
+| Gateway Overhead (ms) | `hourly_request_metrics.avg_overhead_ms` | Time series with 20ms target line |
+| Error Rate by Provider | `hourly_request_metrics` filtered by `error_count > 0` | Time series, grouped by provider |
+| Cache Hit Ratio | `gateway_events` where `event_type IN ('cache.hit', 'cache.miss')` | Gauge (current) + time series (trend) |
+| Active Requests | `gateway.process.stats` events | Stat panel |
+
+### 9.2 Dashboard: RAG Pipeline Health
+
+| Panel | Query Source | Visualization |
+|-------|-------------|---------------|
+| RAG Request Rate | `gateway_events` where `event_type = 'rag.started'` | Time series |
+| Embedding Latency (P50/P95) | `gateway_events` where `event_type = 'rag.embedding.completed'` | Histogram |
+| Vector Search Latency | `gateway_events` where `event_type = 'rag.search.completed'` | Time series |
+| Top Chunk Similarity Distribution | `rag.search.completed` payload `topSimilarity` | Heatmap |
+| RAG Failure Rate | `rag.failed` count / `rag.started` count | Stat + time series |
+| Fallback-to-No-RAG Rate | `rag.failed` where `fallbackToNoRag = true` | Gauge |
+
+### 9.3 Dashboard: MCP Tool Execution
+
+| Panel | Query Source | Visualization |
+|-------|-------------|---------------|
+| MCP Round-Trip Rate | `mcp.round_trip.started` events | Time series |
+| Per-Tool Latency | `mcp.tool.called` grouped by `toolName` | Bar chart |
+| Tool Error Rate | `mcp.tool.called` where `statusCode >= 400` | Table (tool name, error count, rate) |
+| Round-Trip Overhead (ms) | `mcp.round_trip.completed` `totalMs` | Histogram |
+
+### 9.4 Dashboard: Infrastructure
+
+| Panel | Query Source | Visualization |
+|-------|-------------|---------------|
+| Queue Depth | `gateway.queue.depth` events | Time series with alert threshold |
+| Worker Lag | Queue consumer lag metric (queue-specific) | Stat panel |
+| Heap Memory Usage | `gateway.process.stats` `heapUsedMb` | Time series per replica |
+| Event Loop Delay | `gateway.process.stats` `eventLoopDelayMs` | Time series with 100ms alert line |
+| Compression Ratio | TimescaleDB `timescaledb_information.compressed_chunk_stats` | Stat panel |
+
+### 9.5 Alerting Rules
+
+| Alert | Condition | Severity |
+|-------|-----------|----------|
+| High Gateway Overhead | avg `gatewayOverheadMs` > 20ms over 5 min | Warning |
+| Provider Error Spike | error rate > 5% over 5 min | Critical |
+| Queue Backpressure | depth > 10,000 events | Warning |
+| Worker Stopped | no events consumed for 60s | Critical |
+| Memory Leak | heap growth > 100MB over 1 hour | Warning |
+
+---
+
+## 10. Arachne Desktop Mode
+
+Desktop mode provides the full observability pipeline in a single process with no external dependencies beyond SQLite.
+
+### 10.1 InMemoryEventBus
+
+```typescript
+class InMemoryEventBus implements EventBus {
+  private handlers = new Map<string, EventHandler[]>();
+
+  emit(event: GatewayEvent): void {
+    // Dispatch synchronously to all matching handlers.
+    // Events are processed in the same tick — acceptable for single-user load.
+    for (const [pattern, handlers] of this.handlers) {
+      if (this.matches(event.type, pattern)) {
+        for (const handler of handlers) {
+          try {
+            const result = handler(event);
+            if (result instanceof Promise) result.catch(err =>
+              console.error('[eventbus:desktop] handler error:', err)
+            );
+          } catch (err) {
+            console.error('[eventbus:desktop] handler error:', err);
+          }
+        }
+      }
+    }
+  }
+
+  on(pattern: string, handler: EventHandler): void {
+    const list = this.handlers.get(pattern) ?? [];
+    list.push(handler);
+    this.handlers.set(pattern, list);
+  }
+
+  async shutdown(): Promise<void> {
+    this.handlers.clear();
+  }
+
+  private matches(type: string, pattern: string): boolean {
+    if (pattern === '*') return true;
+    if (pattern.endsWith('.*')) {
+      return type.startsWith(pattern.slice(0, -1));
+    }
+    return type === pattern;
+  }
+}
+```
+
+### 10.2 InMemoryCacheService
+
+```typescript
+class InMemoryCacheService implements CacheService {
+  private store = new Map<string, { value: unknown; expiresAt: number }>();
+
+  async get<T>(namespace: CacheNamespace, key: string): Promise<T | undefined> {
+    const entry = this.store.get(`${namespace}:${key}`);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(`${namespace}:${key}`);
+      return undefined;
+    }
+    return entry.value as T;
+  }
+
+  async set<T>(namespace: CacheNamespace, key: string, value: T): Promise<void> {
+    const ttlMs = NAMESPACE_TTL[namespace] ?? 60_000;
+    this.store.set(`${namespace}:${key}`, {
+      value,
+      expiresAt: Date.now() + ttlMs,
+    });
+  }
+
+  async invalidate(namespace: CacheNamespace, key: string): Promise<void> {
+    this.store.delete(`${namespace}:${key}`);
+  }
+}
+```
+
+### 10.3 SQLite Analytics
+
+Desktop mode uses SQLite with the same Recharts dashboards. The `TraceAssembler` writes to a `traces` table in SQLite, and analytics queries use SQLite-compatible SQL:
+
+- `time_bucket()` is replaced by `strftime('%Y-%m-%d %H:00:00', created_at)`.
+- `percentile_cont` is replaced by application-level percentile calculation.
+- No continuous aggregates; queries run against raw data (acceptable at desktop scale).
+
+### 10.4 Feature Matrix
+
+| Capability | Production | Desktop |
+|-----------|-----------|---------|
+| EventBus | QueueEventBus | InMemoryEventBus |
+| Cache | L1 + Redis L2 | InMemoryCacheService |
+| Worker | Separate process | Inline handlers |
+| Time-series DB | TimescaleDB | SQLite |
+| Trace persistence | PostgreSQL | SQLite |
+| Tenant dashboards (Recharts) | Full | Full |
+| Operator dashboards (Grafana) | Full | Not available |
+| Encryption | AES-256-GCM | AES-256-GCM (same) |
+| Multi-replica | Yes | Single process |
+
+---
+
+## 11. Multi-Tenancy in the Event Stream
+
+### 11.1 Tenant as First-Class Field
+
+Every `GatewayEvent` carries `tenantId`. This field is:
+- Set by the gateway after auth resolution.
+- Used by the worker for per-tenant encryption key derivation.
+- Used by continuous aggregates as a segment-by column.
+- Used by Grafana dashboards as a filter variable.
+
+### 11.2 Phase 1: Logical Isolation
+
+All events flow through a single queue topic/stream. The worker processes events for all tenants. Tenant isolation is enforced at the query layer:
+
+- Continuous aggregates include `tenant_id` in `GROUP BY`.
+- Tenant dashboard queries always filter by `tenant_id`.
+- Grafana admin dashboards use a `tenant_id` variable for drill-down.
+
+This is sufficient for early production where tenant count is low and event volume is manageable.
+
+### 11.3 Phase 2: Physical Isolation
+
+As tenant count and event volume grow, introduce per-tenant routing:
+
+```
+Events for tenant A  -->  [queue partition/stream A]  -->  Worker group A
+Events for tenant B  -->  [queue partition/stream B]  -->  Worker group B
+```
+
+- **Routing key:** `tenantId` determines queue partition.
+- **Noisy-neighbor prevention:** A high-volume tenant cannot starve others because each partition has dedicated consumer capacity.
+- **Premium tenants:** Can be assigned dedicated queue partitions with higher throughput guarantees.
+
+The `QueueAdapter` handles routing — the `EventBus.emit()` interface does not change.
+
+---
+
+## 12. Trace Entity Evolution
+
+### 12.1 Current State
+
+The `Trace` entity (`src/domain/entities/Trace.ts`) is a monolithic row written synchronously (batched, but still on the gateway's event loop) after a request completes. It includes:
+
+- Encrypted request/response bodies
+- Latency measurements (total, TTFB, gateway overhead)
+- Token counts and cost estimates
+- RAG metrics (12 fields)
+- Foreign keys to Tenant and Agent
+
+### 12.2 Target State
+
+The `Trace` becomes a **materialized composite** assembled by the worker from lifecycle events:
+
+```
+Gateway                    Worker                         PostgreSQL
+  |                          |                               |
+  |-- request.received ----->|                               |
+  |-- auth.resolved -------->|                               |
+  |-- rag.*.completed ------>|  TraceAssembler collects      |
+  |-- provider.*.completed ->|  events by requestId          |
+  |-- request.completed ---->|                               |
+  |                          |-- assemble + encrypt -------->|
+  |                          |   INSERT INTO traces          |
+  |                          |                               |
+```
+
+**Benefits:**
+- Gateway no longer performs encryption on the hot path.
+- Gateway no longer constructs and holds the full Trace object in memory.
+- Individual events are independently queryable in TimescaleDB for debugging.
+- The Trace row format can evolve without changing the gateway code — only the worker's assembly logic changes.
+
+### 12.3 Schema Compatibility
+
+The existing `traces` table schema is unchanged. The worker populates the same columns from event data. Existing Recharts dashboard queries, portal API endpoints, and admin analytics continue to work without modification.
+
+New fields can be added to `traces` by extracting them from event payloads in the worker, without touching gateway code.
+
+---
+
+## 13. Implementation Phases
+
+### Phase 1: EventBus Interface + Redis Foundation
+
+**Goal:** Establish the abstraction layer and external cache without changing the data flow.
+
+- [ ] Define `EventBus`, `GatewayEvent`, `CacheService` interfaces in `src/observability/interfaces.ts`
+- [ ] Implement `InMemoryEventBus` and `InMemoryCacheService` for desktop mode
+- [ ] Implement `RedisCacheService` with ioredis (L2 only, no L1 yet)
+- [ ] Add `REDIS_URL` env var, graceful fallback when not configured
+- [ ] Wire `createEventBus()` and `createCacheService()` factory functions
+- [ ] Add worker skeleton (`src/worker.ts`) that connects to queue and logs events
+
+**Estimated effort:** 1 week
+
+### Phase 2: Migrate TraceRecorder to EventBus
+
+**Goal:** Replace the in-process `TraceRecorder` with EventBus emissions.
+
+- [ ] Emit `request.received`, `request.completed`, `provider.response.completed` from `src/index.ts`
+- [ ] Implement `TraceAssembler` in the worker
+- [ ] Move encryption from `TraceRecorder.record()` to `TraceAssembler.assemble()`
+- [ ] Worker writes assembled Trace rows to PostgreSQL `traces` table
+- [ ] Validate: tenant dashboards produce identical results
+- [ ] Deprecate `TraceRecorder` (keep as fallback behind feature flag)
+
+**Estimated effort:** 1.5 weeks
+
+### Phase 3: TimescaleDB Extension
+
+**Goal:** Add time-series storage alongside existing PostgreSQL.
+
+- [ ] Enable `timescaledb` extension in PostgreSQL (migration)
+- [ ] Create `gateway_events` hypertable (migration)
+- [ ] Create `hourly_request_metrics` and `daily_request_metrics` continuous aggregates
+- [ ] Add `TimeSeriesWriter` to worker: dual-write events to hypertable
+- [ ] Configure compression policy (7 days) and retention policy (90 days)
+- [ ] Validate: Grafana can query continuous aggregates
+
+**Estimated effort:** 1 week
+
+### Phase 4: Full Event Instrumentation
+
+**Goal:** Emit all 25+ lifecycle events across the request handler.
+
+- [ ] Instrument auth middleware (`auth.resolved`, `auth.failed`)
+- [ ] Instrument conversation subsystem (`conversation.*` events)
+- [ ] Instrument RAG pipeline (`rag.*` events)
+- [ ] Instrument agent application (`agent.config_applied`)
+- [ ] Instrument streaming (`stream.first_byte`, `stream.completed`)
+- [ ] Instrument MCP round-trip (`mcp.*` events)
+- [ ] Instrument cache operations (`cache.*` events)
+- [ ] Add periodic health emitters (`gateway.queue.depth`, `gateway.process.stats`)
+
+**Estimated effort:** 2 weeks
+
+### Phase 5: Redis Cache Migration (L1/L2)
+
+**Goal:** Replace the hand-rolled LRU in `src/auth.ts` with two-tier caching.
+
+- [ ] Implement L1 in-process cache with TTL and capacity limit
+- [ ] Wire L1 -> L2 -> DB fallthrough in `CacheService`
+- [ ] Migrate `registerAuthMiddleware()` to use `CacheService` for tenant resolution
+- [ ] Add pub/sub invalidation channel and subscriber
+- [ ] Update `invalidateCachedKey()` and `invalidateAllKeysForTenant()` to publish invalidation
+- [ ] Add `provider_config` and `agent_config` cache namespaces
+
+**Estimated effort:** 1 week
+
+### Phase 6: Grafana Operator Dashboards
+
+**Goal:** Deploy Grafana and build the four operator dashboards.
+
+- [ ] Add Grafana to `docker-compose.yml` with TimescaleDB data source
+- [ ] Build Gateway Overview dashboard
+- [ ] Build RAG Pipeline Health dashboard
+- [ ] Build MCP Tool Execution dashboard
+- [ ] Build Infrastructure dashboard
+- [ ] Configure alerting rules (overhead, error spike, queue depth, worker health)
+- [ ] Version-control dashboard JSON in `infra/grafana/dashboards/`
+
+**Estimated effort:** 1.5 weeks
+
+### Phase 7: Desktop Mode Adapters
+
+**Goal:** Ensure single-binary mode works with full analytics parity.
+
+- [ ] Wire `InMemoryEventBus` when `ARACHNE_MODE=desktop` or `DB_DRIVER=sqlite`
+- [ ] Wire `InMemoryCacheService` when Redis is not configured
+- [ ] Adapt `TraceAssembler` to write to SQLite
+- [ ] Implement SQLite-compatible analytics queries (replace `time_bucket`, `percentile_cont`)
+- [ ] Validate: Recharts dashboards render correctly with SQLite backend
+- [ ] Add integration tests for desktop mode pipeline
+
+**Estimated effort:** 1 week
+
+---
+
+**Total estimated effort:** ~9-10 weeks for a single engineer, with phases 1-2 providing immediate value (decoupled tracing, encryption off hot path) and subsequent phases layering on deeper analytics capabilities.

--- a/docs/system_specs/queue_spike.md
+++ b/docs/system_specs/queue_spike.md
@@ -1,0 +1,1220 @@
+# Queue Technology Spike: Durable Trace Recording
+
+**Status:** Draft
+**Author:** Spike investigation
+**Date:** 2026-03-16
+
+## Problem Statement
+
+The current `TraceRecorder` in `src/tracing.ts` buffers trace events in an in-memory array and flushes to PostgreSQL every 5 seconds or 100 rows. If the gateway process crashes, all buffered traces are lost. We need a durable message queue so that:
+
+1. Trace data survives gateway crashes
+2. Publishing remains non-blocking (< 1ms on the hot path)
+3. A separate worker container consumes events and writes to TimescaleDB
+4. Desktop mode (single process, zero dependencies) still works via an in-memory adapter
+5. The same queue infrastructure can later support agent team orchestration (sagas/workflows)
+
+## Common Interface
+
+All adapters implement this interface. The gateway imports `EventQueue` and never knows which backend is active.
+
+```typescript
+// src/queue/types.ts
+
+import type { TraceInput } from '../tracing.js';
+
+export interface TraceEvent {
+  id: string;          // UUID, assigned at publish time
+  timestamp: number;   // Date.now()
+  payload: TraceInput;
+}
+
+export type TraceHandler = (event: TraceEvent) => Promise<void>;
+
+export interface EventQueue {
+  /** One-time setup. Called at server startup. */
+  connect(): Promise<void>;
+
+  /** Publish a trace event. Must be non-blocking on the hot path. */
+  publish(event: TraceEvent): Promise<void>;
+
+  /**
+   * Start consuming events. Called by the worker process.
+   * The handler receives one event at a time; throwing triggers retry.
+   */
+  subscribe(handler: TraceHandler): Promise<void>;
+
+  /** Graceful shutdown. Flushes pending work and closes connections. */
+  close(): Promise<void>;
+}
+```
+
+Factory that reads config and returns the right adapter:
+
+```typescript
+// src/queue/index.ts
+
+import type { EventQueue } from './types.js';
+
+export function createQueue(): EventQueue {
+  const driver = process.env.QUEUE_DRIVER ?? 'memory';
+
+  switch (driver) {
+    case 'bullmq':
+      return new (require('./bullmq.js').BullMQQueue)();
+    case 'temporal':
+      return new (require('./temporal.js').TemporalQueue)();
+    case 'rabbitmq':
+      return new (require('./rabbitmq.js').RabbitMQQueue)();
+    case 'azuresb':
+      return new (require('./azuresb.js').AzureServiceBusQueue)();
+    case 'memory':
+    default:
+      return new (require('./memory.js').InMemoryQueue)();
+  }
+}
+```
+
+---
+
+## 1. BullMQ (Redis-backed)
+
+**npm:** `bullmq` (single package, includes both producer and worker)
+**Requires:** Redis 7+
+
+### a. Producer Code Sample
+
+```typescript
+// src/queue/bullmq.ts
+
+import { Queue, Worker, type Job } from 'bullmq';
+import { randomUUID } from 'node:crypto';
+import type { EventQueue, TraceEvent, TraceHandler } from './types.js';
+
+const QUEUE_NAME = 'arachne:traces';
+
+export class BullMQQueue implements EventQueue {
+  private queue!: Queue;
+  private worker?: Worker;
+
+  private readonly connection = {
+    host: process.env.REDIS_HOST ?? 'localhost',
+    port: Number(process.env.REDIS_PORT ?? 6379),
+  };
+
+  async connect(): Promise<void> {
+    this.queue = new Queue(QUEUE_NAME, {
+      connection: this.connection,
+      defaultJobOptions: {
+        attempts: 5,
+        backoff: { type: 'exponential', delay: 1_000 },
+        removeOnComplete: 1_000,  // keep last 1k for debugging
+        removeOnFail: 5_000,      // keep last 5k failures
+      },
+    });
+  }
+
+  async publish(event: TraceEvent): Promise<void> {
+    // add() returns a promise but the actual Redis XADD is sub-ms
+    await this.queue.add('trace', event, { jobId: event.id });
+  }
+
+  async subscribe(handler: TraceHandler): Promise<void> {
+    this.worker = new Worker(
+      QUEUE_NAME,
+      async (job: Job<TraceEvent>) => {
+        await handler(job.data);
+      },
+      {
+        connection: this.connection,
+        concurrency: 10,
+        limiter: { max: 500, duration: 1_000 },  // max 500 jobs/sec
+      },
+    );
+
+    this.worker.on('failed', (job, err) => {
+      console.error(`[bullmq] Job ${job?.id} failed: ${err.message}`);
+    });
+  }
+
+  async close(): Promise<void> {
+    await this.worker?.close();
+    await this.queue?.close();
+  }
+}
+```
+
+**Gateway usage (replacing TraceRecorder.record):**
+
+```typescript
+// src/index.ts (at startup)
+import { createQueue } from './queue/index.js';
+import { randomUUID } from 'node:crypto';
+import { encryptTraceBody } from './encryption.js';
+
+const queue = createQueue();
+await queue.connect();
+
+// In the request handler, replacing traceRecorder.record(trace):
+const event: TraceEvent = {
+  id: randomUUID(),
+  timestamp: Date.now(),
+  payload: trace,  // TraceInput — encryption moves to the worker
+};
+void queue.publish(event);  // fire-and-forget
+```
+
+### b. Consumer/Worker Code Sample
+
+```typescript
+// src/worker.ts — separate entrypoint: `node dist/worker.js`
+
+import { createQueue } from './queue/index.js';
+import { initOrm } from './orm.js';
+import { encryptTraceBody } from './encryption.js';
+import { Trace } from './domain/entities/Trace.js';
+import { Tenant } from './domain/entities/Tenant.js';
+import { Agent } from './domain/entities/Agent.js';
+import { randomUUID } from 'node:crypto';
+import type { TraceEvent } from './queue/types.js';
+
+async function main() {
+  const orm = await initOrm();
+  const em = orm.em;
+  const queue = createQueue();
+  await queue.connect();
+
+  await queue.subscribe(async (event: TraceEvent) => {
+    const { payload: input } = event;
+    const forkedEm = em.fork();
+
+    // Encryption happens here, off the gateway hot path
+    const reqBodyJson = JSON.stringify(input.requestBody);
+    const { ciphertext: reqCt, iv: reqIv } = encryptTraceBody(input.tenantId, reqBodyJson);
+
+    let resCt: string | null = null;
+    let resIv: string | null = null;
+    if (input.responseBody != null) {
+      const enc = encryptTraceBody(input.tenantId, JSON.stringify(input.responseBody));
+      resCt = enc.ciphertext;
+      resIv = enc.iv;
+    }
+
+    const trace = new Trace();
+    trace.id = event.id;
+    trace.tenant = forkedEm.getReference(Tenant, input.tenantId);
+    trace.agent = input.agentId
+      ? forkedEm.getReference(Agent, input.agentId)
+      : null;
+    trace.requestId = input.requestId ?? randomUUID();
+    trace.model = input.model;
+    trace.provider = input.provider;
+    trace.endpoint = input.endpoint ?? '/v1/chat/completions';
+    trace.requestBody = reqCt;
+    trace.requestIv = reqIv;
+    trace.responseBody = resCt;
+    trace.responseIv = resIv;
+    trace.latencyMs = input.latencyMs;
+    trace.promptTokens = input.promptTokens ?? null;
+    trace.completionTokens = input.completionTokens ?? null;
+    trace.totalTokens = input.totalTokens ?? null;
+    trace.estimatedCostUsd = null;
+    trace.encryptionKeyVersion = 1;
+    trace.statusCode = input.statusCode ?? null;
+    trace.ttfbMs = input.ttfbMs ?? null;
+    trace.gatewayOverheadMs = input.gatewayOverheadMs ?? null;
+    trace.createdAt = new Date(event.timestamp);
+    // RAG fields
+    trace.knowledgeBaseId = input.knowledgeBaseId ?? null;
+    trace.embeddingAgentId = input.embeddingAgentId ?? null;
+    trace.ragRetrievalLatencyMs = input.ragRetrievalLatencyMs ?? null;
+    trace.embeddingLatencyMs = input.embeddingLatencyMs ?? null;
+    trace.vectorSearchLatencyMs = input.vectorSearchLatencyMs ?? null;
+    trace.retrievedChunkCount = input.retrievedChunkCount ?? null;
+    trace.topChunkSimilarity = input.topChunkSimilarity ?? null;
+    trace.avgChunkSimilarity = input.avgChunkSimilarity ?? null;
+    trace.contextTokensAdded = input.contextTokensAdded ?? null;
+    trace.ragOverheadTokens = input.ragOverheadTokens ?? null;
+    trace.ragCostOverheadUsd = input.ragCostOverheadUsd ?? null;
+    trace.ragStageFailed = input.ragStageFailed ?? null;
+    trace.fallbackToNoRag = input.fallbackToNoRag ?? null;
+
+    forkedEm.persist(trace);
+    await forkedEm.flush();
+  });
+
+  console.log('[worker] Listening for trace events...');
+}
+
+main().catch((err) => {
+  console.error('[worker] Fatal:', err);
+  process.exit(1);
+});
+```
+
+### c. Desktop In-Memory Adapter
+
+```typescript
+// src/queue/memory.ts
+
+import type { EventQueue, TraceEvent, TraceHandler } from './types.js';
+
+/**
+ * In-memory queue for Desktop mode. Processes events in a microtask,
+ * matching the current TraceRecorder behavior without external dependencies.
+ */
+export class InMemoryQueue implements EventQueue {
+  private buffer: TraceEvent[] = [];
+  private handler?: TraceHandler;
+  private timer?: ReturnType<typeof setInterval>;
+  private processing = false;
+
+  private readonly batchSize = 100;
+  private readonly flushIntervalMs = 5_000;
+
+  async connect(): Promise<void> {
+    // No-op — nothing to connect to
+  }
+
+  async publish(event: TraceEvent): Promise<void> {
+    this.buffer.push(event);
+    if (this.buffer.length >= this.batchSize) {
+      void this.drain();
+    }
+  }
+
+  async subscribe(handler: TraceHandler): Promise<void> {
+    this.handler = handler;
+    this.timer = setInterval(() => { void this.drain(); }, this.flushIntervalMs);
+    this.timer.unref?.();
+  }
+
+  private async drain(): Promise<void> {
+    if (this.processing || this.buffer.length === 0 || !this.handler) return;
+    this.processing = true;
+
+    const batch = this.buffer.splice(0);
+    for (const event of batch) {
+      try {
+        await this.handler(event);
+      } catch (err) {
+        console.error('[memory-queue] Handler failed:', err);
+        // No retry in memory mode — matches current TraceRecorder behavior
+      }
+    }
+    this.processing = false;
+  }
+
+  async close(): Promise<void> {
+    if (this.timer) clearInterval(this.timer);
+    await this.drain();
+  }
+}
+```
+
+### d. Docker Compose Addition
+
+```yaml
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes  # AOF persistence
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  trace-worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: node dist/worker.js
+    depends_on:
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://loom:loom_dev_password@postgres:5432/loom
+      QUEUE_DRIVER: bullmq
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      ENCRYPTION_MASTER_KEY: "0000000000000000000000000000000000000000000000000000000000000001"
+
+# Add to volumes:
+  redis_data:
+```
+
+### e. Error Handling
+
+```typescript
+// Retry is configured in defaultJobOptions (see producer above):
+// attempts: 5, exponential backoff starting at 1s → 1s, 2s, 4s, 8s, 16s
+
+// Dead-letter: BullMQ moves jobs to a "failed" set after all attempts are
+// exhausted. Jobs remain visible in Bull Board for inspection.
+// To reprocess failed jobs:
+import { Queue } from 'bullmq';
+const queue = new Queue('arachne:traces', { connection });
+const failed = await queue.getFailed(0, 100);
+for (const job of failed) {
+  await job.retry();
+}
+```
+
+**When the worker is down:** Redis buffers all published jobs. BullMQ uses Redis Streams (XADD/XREADGROUP), so messages persist until consumed. Memory usage grows with backlog — Redis `maxmemory` should be configured. At ~2 KB per trace event, 1 GB of Redis holds ~500,000 buffered traces.
+
+### f. Agent Team Readiness
+
+BullMQ has no built-in saga or workflow primitives. Multi-agent orchestration would require building a state machine on top of BullMQ's job dependencies and flow producer (`FlowProducer`). The `FlowProducer` supports parent-child job trees, which maps loosely to coordinator-dispatches-to-sub-agents, but partial failure handling, compensation steps, and timeout coordination would all be custom code.
+
+**Verdict:** Workable for simple fan-out patterns. Inadequate for complex multi-step agent orchestration without significant custom work.
+
+---
+
+## 2. Temporal.io
+
+**npm:** `@temporalio/client`, `@temporalio/worker`, `@temporalio/workflow`, `@temporalio/activity`
+**Requires:** Temporal server (single Go binary) + persistence backend (can use existing PostgreSQL)
+
+### a. Producer Code Sample
+
+```typescript
+// src/queue/temporal.ts
+
+import { Client, Connection } from '@temporalio/client';
+import type { EventQueue, TraceEvent, TraceHandler } from './types.js';
+
+const TASK_QUEUE = 'arachne-traces';
+
+export class TemporalQueue implements EventQueue {
+  private client!: Client;
+  private workerInstance?: import('@temporalio/worker').Worker;
+
+  async connect(): Promise<void> {
+    const connection = await Connection.connect({
+      address: process.env.TEMPORAL_ADDRESS ?? 'localhost:7233',
+    });
+    this.client = new Client({ connection });
+  }
+
+  async publish(event: TraceEvent): Promise<void> {
+    // Start a workflow execution — Temporal persists it immediately
+    await this.client.workflow.start('processTrace', {
+      taskQueue: TASK_QUEUE,
+      workflowId: `trace-${event.id}`,
+      args: [event],
+    });
+  }
+
+  async subscribe(handler: TraceHandler): Promise<void> {
+    const { Worker } = await import('@temporalio/worker');
+
+    this.workerInstance = await Worker.create({
+      workflowsPath: new URL('./temporal-workflows.js', import.meta.url).pathname,
+      activities: {
+        persistTrace: async (event: TraceEvent) => {
+          await handler(event);
+        },
+      },
+      taskQueue: TASK_QUEUE,
+      maxConcurrentWorkflowTaskExecutions: 50,
+      maxConcurrentActivityTaskExecutions: 20,
+    });
+
+    // Run blocks until worker is shut down
+    void this.workerInstance.run();
+  }
+
+  async close(): Promise<void> {
+    this.workerInstance?.shutdown();
+  }
+}
+```
+
+**Workflow definition (must be in a separate file for Temporal's deterministic sandbox):**
+
+```typescript
+// src/queue/temporal-workflows.ts
+
+import { proxyActivities } from '@temporalio/workflow';
+import type { TraceEvent } from './types.js';
+
+const { persistTrace } = proxyActivities<{
+  persistTrace(event: TraceEvent): Promise<void>;
+}>({
+  startToCloseTimeout: '30s',
+  retry: {
+    maximumAttempts: 5,
+    initialInterval: '1s',
+    backoffCoefficient: 2,
+    maximumInterval: '30s',
+  },
+});
+
+export async function processTrace(event: TraceEvent): Promise<void> {
+  await persistTrace(event);
+}
+```
+
+### b. Consumer/Worker Code Sample
+
+The worker is part of the `subscribe()` call above. In production, the worker runs as a separate process:
+
+```typescript
+// src/temporal-worker.ts — entrypoint: `node dist/temporal-worker.js`
+
+import { Worker } from '@temporalio/worker';
+import { initOrm } from './orm.js';
+import { encryptTraceBody } from './encryption.js';
+import { Trace } from './domain/entities/Trace.js';
+import { Tenant } from './domain/entities/Tenant.js';
+import { Agent } from './domain/entities/Agent.js';
+import { randomUUID } from 'node:crypto';
+import type { TraceEvent } from './queue/types.js';
+
+async function main() {
+  const orm = await initOrm();
+  const em = orm.em;
+
+  const worker = await Worker.create({
+    workflowsPath: new URL('./queue/temporal-workflows.js', import.meta.url).pathname,
+    activities: {
+      persistTrace: async (event: TraceEvent) => {
+        const { payload: input } = event;
+        const forkedEm = em.fork();
+
+        const reqBodyJson = JSON.stringify(input.requestBody);
+        const { ciphertext: reqCt, iv: reqIv } = encryptTraceBody(input.tenantId, reqBodyJson);
+
+        let resCt: string | null = null;
+        let resIv: string | null = null;
+        if (input.responseBody != null) {
+          const enc = encryptTraceBody(input.tenantId, JSON.stringify(input.responseBody));
+          resCt = enc.ciphertext;
+          resIv = enc.iv;
+        }
+
+        const trace = new Trace();
+        trace.id = event.id;
+        trace.tenant = forkedEm.getReference(Tenant, input.tenantId);
+        trace.agent = input.agentId
+          ? forkedEm.getReference(Agent, input.agentId)
+          : null;
+        trace.requestId = input.requestId ?? randomUUID();
+        trace.model = input.model;
+        trace.provider = input.provider;
+        trace.endpoint = input.endpoint ?? '/v1/chat/completions';
+        trace.requestBody = reqCt;
+        trace.requestIv = reqIv;
+        trace.responseBody = resCt;
+        trace.responseIv = resIv;
+        trace.latencyMs = input.latencyMs;
+        trace.promptTokens = input.promptTokens ?? null;
+        trace.completionTokens = input.completionTokens ?? null;
+        trace.totalTokens = input.totalTokens ?? null;
+        trace.estimatedCostUsd = null;
+        trace.encryptionKeyVersion = 1;
+        trace.statusCode = input.statusCode ?? null;
+        trace.ttfbMs = input.ttfbMs ?? null;
+        trace.gatewayOverheadMs = input.gatewayOverheadMs ?? null;
+        trace.createdAt = new Date(event.timestamp);
+        // RAG fields
+        trace.knowledgeBaseId = input.knowledgeBaseId ?? null;
+        trace.embeddingAgentId = input.embeddingAgentId ?? null;
+        trace.ragRetrievalLatencyMs = input.ragRetrievalLatencyMs ?? null;
+        trace.embeddingLatencyMs = input.embeddingLatencyMs ?? null;
+        trace.vectorSearchLatencyMs = input.vectorSearchLatencyMs ?? null;
+        trace.retrievedChunkCount = input.retrievedChunkCount ?? null;
+        trace.topChunkSimilarity = input.topChunkSimilarity ?? null;
+        trace.avgChunkSimilarity = input.avgChunkSimilarity ?? null;
+        trace.contextTokensAdded = input.contextTokensAdded ?? null;
+        trace.ragOverheadTokens = input.ragOverheadTokens ?? null;
+        trace.ragCostOverheadUsd = input.ragCostOverheadUsd ?? null;
+        trace.ragStageFailed = input.ragStageFailed ?? null;
+        trace.fallbackToNoRag = input.fallbackToNoRag ?? null;
+
+        forkedEm.persist(trace);
+        await forkedEm.flush();
+      },
+    },
+    taskQueue: 'arachne-traces',
+    maxConcurrentWorkflowTaskExecutions: 50,
+    maxConcurrentActivityTaskExecutions: 20,
+  });
+
+  console.log('[temporal-worker] Starting...');
+  await worker.run();
+}
+
+main().catch((err) => {
+  console.error('[temporal-worker] Fatal:', err);
+  process.exit(1);
+});
+```
+
+### c. Desktop In-Memory Adapter
+
+Temporal has no in-memory mode. Desktop would use the same `InMemoryQueue` from section 1c. The `EventQueue` interface abstracts this cleanly — if `QUEUE_DRIVER=memory`, Temporal is never imported.
+
+### d. Docker Compose Addition
+
+```yaml
+  temporal:
+    image: temporalio/auto-setup:latest
+    ports:
+      - "7233:7233"      # gRPC frontend
+    environment:
+      - DB=postgresql
+      - DB_PORT=5432
+      - POSTGRES_USER=loom
+      - POSTGRES_PWD=loom_dev_password
+      - POSTGRES_SEEDS=postgres
+      - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-sql.yaml
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  temporal-ui:
+    image: temporalio/ui:latest
+    ports:
+      - "8080:8080"
+    environment:
+      - TEMPORAL_ADDRESS=temporal:7233
+
+  trace-worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: node dist/temporal-worker.js
+    depends_on:
+      temporal:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://loom:loom_dev_password@postgres:5432/loom
+      TEMPORAL_ADDRESS: temporal:7233
+      ENCRYPTION_MASTER_KEY: "0000000000000000000000000000000000000000000000000000000000000001"
+```
+
+### e. Error Handling
+
+Temporal handles retries declaratively in the workflow definition (see `proxyActivities` retry config above). Failed activities are retried automatically. After all attempts are exhausted, the workflow execution fails and is visible in the Temporal UI with full execution history.
+
+**When the worker is down:** Temporal server queues workflow tasks in its own database. When the worker comes back online, it picks up all pending tasks. There is no message loss — Temporal's persistence guarantees are its core value proposition. No backpressure configuration needed on the producer side.
+
+**DLQ equivalent:** Failed workflows remain in "Failed" state in Temporal. They can be reset or restarted via the CLI (`tctl`) or the UI. There is no separate dead-letter queue concept because Temporal retains full execution history.
+
+### f. Agent Team Readiness
+
+This is Temporal's strongest suit. Multi-agent orchestration maps directly to Temporal's programming model:
+
+```typescript
+// Example: agent team coordination as a Temporal workflow
+import { proxyActivities, sleep } from '@temporalio/workflow';
+
+const { dispatchToAgent, collectResult } = proxyActivities<AgentActivities>({
+  startToCloseTimeout: '5m',
+  retry: { maximumAttempts: 3 },
+});
+
+export async function coordinateAgentTeam(task: TeamTask): Promise<TeamResult> {
+  // Fan-out to sub-agents
+  const handles = task.agents.map((agent) =>
+    dispatchToAgent({ agent, task: task.subtask })
+  );
+
+  const results = await Promise.allSettled(handles);
+
+  // Handle partial failures — compensation / fallback
+  const failures = results.filter((r) => r.status === 'rejected');
+  if (failures.length > 0) {
+    await compensatePartialFailures(failures);
+  }
+
+  return aggregateResults(results);
+}
+```
+
+Temporal provides: saga compensation via try/catch, child workflows for sub-agent isolation, timers and deadlines, signal/query for external coordination, versioning for workflow evolution.
+
+**Verdict:** Purpose-built for exactly this use case. Best-in-class saga and orchestration support.
+
+---
+
+## 3. RabbitMQ
+
+**npm:** `amqplib` (low-level AMQP 0-9-1 client)
+**Requires:** RabbitMQ server (Erlang runtime, ~150 MB image)
+
+### a. Producer Code Sample
+
+```typescript
+// src/queue/rabbitmq.ts
+
+import amqplib, { type Channel, type Connection } from 'amqplib';
+import type { EventQueue, TraceEvent, TraceHandler } from './types.js';
+
+const EXCHANGE = 'arachne.traces';
+const QUEUE = 'arachne.traces.persist';
+const DLX = 'arachne.traces.dlx';
+const DLQ = 'arachne.traces.dlq';
+const ROUTING_KEY = 'trace.created';
+
+export class RabbitMQQueue implements EventQueue {
+  private conn!: Connection;
+  private pubChannel!: Channel;
+  private subChannel?: Channel;
+
+  private readonly url =
+    process.env.RABBITMQ_URL ?? 'amqp://guest:guest@localhost:5672';
+
+  async connect(): Promise<void> {
+    this.conn = await amqplib.connect(this.url);
+
+    this.pubChannel = await this.conn.createConfirmChannel();
+
+    // Declare topology
+    await this.pubChannel.assertExchange(DLX, 'direct', { durable: true });
+    await this.pubChannel.assertQueue(DLQ, { durable: true });
+    await this.pubChannel.bindQueue(DLQ, DLX, ROUTING_KEY);
+
+    await this.pubChannel.assertExchange(EXCHANGE, 'direct', { durable: true });
+    await this.pubChannel.assertQueue(QUEUE, {
+      durable: true,
+      arguments: {
+        'x-dead-letter-exchange': DLX,
+        'x-dead-letter-routing-key': ROUTING_KEY,
+      },
+    });
+    await this.pubChannel.bindQueue(QUEUE, EXCHANGE, ROUTING_KEY);
+  }
+
+  async publish(event: TraceEvent): Promise<void> {
+    const body = Buffer.from(JSON.stringify(event));
+    this.pubChannel.publish(EXCHANGE, ROUTING_KEY, body, {
+      persistent: true,     // survives broker restart
+      messageId: event.id,
+      timestamp: event.timestamp,
+      contentType: 'application/json',
+    });
+    // Publisher confirms ensure the broker has accepted the message.
+    // waitForConfirms() batches under the hood; typical latency ~0.5ms.
+    await this.pubChannel.waitForConfirms();
+  }
+
+  async subscribe(handler: TraceHandler): Promise<void> {
+    this.subChannel = await this.conn.createChannel();
+    await this.subChannel.prefetch(10);
+
+    await this.subChannel.consume(QUEUE, async (msg) => {
+      if (!msg) return;
+
+      const event: TraceEvent = JSON.parse(msg.content.toString());
+      const attempt = (msg.properties.headers?.['x-death']?.[0]?.count ?? 0) + 1;
+
+      try {
+        await handler(event);
+        this.subChannel!.ack(msg);
+      } catch (err) {
+        console.error(`[rabbitmq] Handler failed (attempt ${attempt}):`, err);
+        if (attempt >= 5) {
+          // Exhausted retries — send to DLQ via reject(requeue=false)
+          this.subChannel!.reject(msg, false);
+        } else {
+          // Requeue for retry
+          this.subChannel!.nack(msg, false, true);
+        }
+      }
+    });
+  }
+
+  async close(): Promise<void> {
+    await this.subChannel?.close();
+    await this.pubChannel?.close();
+    await this.conn?.close();
+  }
+}
+```
+
+### b. Consumer/Worker Code Sample
+
+```typescript
+// src/worker.ts — same entrypoint pattern as BullMQ
+
+import { createQueue } from './queue/index.js';
+import { initOrm } from './orm.js';
+import { encryptTraceBody } from './encryption.js';
+import { Trace } from './domain/entities/Trace.js';
+import { Tenant } from './domain/entities/Tenant.js';
+import { Agent } from './domain/entities/Agent.js';
+import { randomUUID } from 'node:crypto';
+import type { TraceEvent } from './queue/types.js';
+
+async function main() {
+  const orm = await initOrm();
+  const em = orm.em;
+  const queue = createQueue(); // QUEUE_DRIVER=rabbitmq
+  await queue.connect();
+
+  await queue.subscribe(async (event: TraceEvent) => {
+    const { payload: input } = event;
+    const forkedEm = em.fork();
+
+    // Same trace persistence logic as BullMQ worker (see section 1b)
+    const reqBodyJson = JSON.stringify(input.requestBody);
+    const { ciphertext: reqCt, iv: reqIv } = encryptTraceBody(input.tenantId, reqBodyJson);
+
+    let resCt: string | null = null;
+    let resIv: string | null = null;
+    if (input.responseBody != null) {
+      const enc = encryptTraceBody(input.tenantId, JSON.stringify(input.responseBody));
+      resCt = enc.ciphertext;
+      resIv = enc.iv;
+    }
+
+    const trace = new Trace();
+    trace.id = event.id;
+    trace.tenant = forkedEm.getReference(Tenant, input.tenantId);
+    trace.agent = input.agentId ? forkedEm.getReference(Agent, input.agentId) : null;
+    trace.requestId = input.requestId ?? randomUUID();
+    trace.model = input.model;
+    trace.provider = input.provider;
+    trace.endpoint = input.endpoint ?? '/v1/chat/completions';
+    trace.requestBody = reqCt;
+    trace.requestIv = reqIv;
+    trace.responseBody = resCt;
+    trace.responseIv = resIv;
+    trace.latencyMs = input.latencyMs;
+    trace.promptTokens = input.promptTokens ?? null;
+    trace.completionTokens = input.completionTokens ?? null;
+    trace.totalTokens = input.totalTokens ?? null;
+    trace.estimatedCostUsd = null;
+    trace.encryptionKeyVersion = 1;
+    trace.statusCode = input.statusCode ?? null;
+    trace.ttfbMs = input.ttfbMs ?? null;
+    trace.gatewayOverheadMs = input.gatewayOverheadMs ?? null;
+    trace.createdAt = new Date(event.timestamp);
+    trace.knowledgeBaseId = input.knowledgeBaseId ?? null;
+    trace.embeddingAgentId = input.embeddingAgentId ?? null;
+    trace.ragRetrievalLatencyMs = input.ragRetrievalLatencyMs ?? null;
+    trace.embeddingLatencyMs = input.embeddingLatencyMs ?? null;
+    trace.vectorSearchLatencyMs = input.vectorSearchLatencyMs ?? null;
+    trace.retrievedChunkCount = input.retrievedChunkCount ?? null;
+    trace.topChunkSimilarity = input.topChunkSimilarity ?? null;
+    trace.avgChunkSimilarity = input.avgChunkSimilarity ?? null;
+    trace.contextTokensAdded = input.contextTokensAdded ?? null;
+    trace.ragOverheadTokens = input.ragOverheadTokens ?? null;
+    trace.ragCostOverheadUsd = input.ragCostOverheadUsd ?? null;
+    trace.ragStageFailed = input.ragStageFailed ?? null;
+    trace.fallbackToNoRag = input.fallbackToNoRag ?? null;
+
+    forkedEm.persist(trace);
+    await forkedEm.flush();
+  });
+
+  console.log('[worker] Listening for trace events...');
+}
+
+main().catch((err) => {
+  console.error('[worker] Fatal:', err);
+  process.exit(1);
+});
+```
+
+### c. Desktop In-Memory Adapter
+
+Same `InMemoryQueue` from section 1c. RabbitMQ has no embeddable mode for Node.js.
+
+### d. Docker Compose Addition
+
+```yaml
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    ports:
+      - "5672:5672"    # AMQP
+      - "15672:15672"  # Management UI
+    environment:
+      RABBITMQ_DEFAULT_USER: arachne
+      RABBITMQ_DEFAULT_PASS: arachne_dev
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_running"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  trace-worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: node dist/worker.js
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://loom:loom_dev_password@postgres:5432/loom
+      QUEUE_DRIVER: rabbitmq
+      RABBITMQ_URL: amqp://arachne:arachne_dev@rabbitmq:5672
+      ENCRYPTION_MASTER_KEY: "0000000000000000000000000000000000000000000000000000000000000001"
+
+# Add to volumes:
+  rabbitmq_data:
+```
+
+### e. Error Handling
+
+Retry is handled via nack/requeue (see consumer code above). The `x-death` header tracks retry count. After 5 failures, the message is rejected and routed to the DLQ via the dead-letter exchange.
+
+For more sophisticated retry with delays, use RabbitMQ's delayed message exchange plugin or a TTL-based retry pattern with intermediate queues:
+
+```typescript
+// TTL retry queue pattern (per-attempt delay escalation)
+// Queue: arachne.traces.retry.1 (TTL: 1s)  → re-routes to main exchange
+// Queue: arachne.traces.retry.2 (TTL: 5s)  → re-routes to main exchange
+// Queue: arachne.traces.retry.3 (TTL: 30s) → re-routes to main exchange
+// Adds significant topology complexity compared to BullMQ's built-in backoff.
+```
+
+**When the worker is down:** RabbitMQ persists durable messages to disk. Messages accumulate until the worker reconnects. Memory and disk alarms trigger flow control (backpressure to publishers) when thresholds are exceeded. Default disk free limit is 50 MB.
+
+### f. Agent Team Readiness
+
+RabbitMQ is a message broker, not a workflow engine. Saga orchestration would require:
+- Custom state tracking in a database
+- Correlation IDs to link related messages
+- Timeout management via delayed messages or external schedulers
+- Compensation logic wired through additional exchanges/queues
+
+Some libraries (e.g., NServiceBus for .NET) provide saga support on top of RabbitMQ, but there is no equivalent mature library for Node.js/TypeScript.
+
+**Verdict:** Strong as a message broker, but adds no value for saga orchestration. Similar to BullMQ in requiring custom workflow code.
+
+---
+
+## 4. Azure Service Bus
+
+**npm:** `@azure/service-bus`
+**Requires:** Azure subscription (managed) or Azure Service Bus Emulator (local dev)
+
+### a. Producer Code Sample
+
+```typescript
+// src/queue/azuresb.ts
+
+import {
+  ServiceBusClient,
+  type ServiceBusSender,
+  type ServiceBusReceiver,
+  type ProcessErrorArgs,
+} from '@azure/service-bus';
+import type { EventQueue, TraceEvent, TraceHandler } from './types.js';
+
+const QUEUE_NAME = 'arachne-traces';
+
+export class AzureServiceBusQueue implements EventQueue {
+  private client!: ServiceBusClient;
+  private sender!: ServiceBusSender;
+  private receiver?: ServiceBusReceiver;
+
+  private readonly connectionString =
+    process.env.AZURE_SERVICEBUS_CONNECTION_STRING ?? '';
+
+  async connect(): Promise<void> {
+    this.client = new ServiceBusClient(this.connectionString);
+    this.sender = this.client.createSender(QUEUE_NAME);
+  }
+
+  async publish(event: TraceEvent): Promise<void> {
+    await this.sender.sendMessages({
+      body: event,
+      messageId: event.id,
+      contentType: 'application/json',
+      subject: 'trace.created',
+      applicationProperties: {
+        tenantId: event.payload.tenantId,
+      },
+    });
+  }
+
+  async subscribe(handler: TraceHandler): Promise<void> {
+    this.receiver = this.client.createReceiver(QUEUE_NAME, {
+      receiveMode: 'peekLock',
+    });
+
+    this.receiver.subscribe({
+      processMessage: async (message) => {
+        const event = message.body as TraceEvent;
+        await handler(event);
+        // Auto-completed on success when using subscribe()
+      },
+      processError: async (args: ProcessErrorArgs) => {
+        console.error(
+          `[azuresb] Error from ${args.errorSource}: ${args.error.message}`,
+        );
+      },
+    }, {
+      maxConcurrentCalls: 10,
+      autoCompleteMessages: true,
+    });
+  }
+
+  async close(): Promise<void> {
+    await this.receiver?.close();
+    await this.sender?.close();
+    await this.client?.close();
+  }
+}
+```
+
+### b. Consumer/Worker Code Sample
+
+```typescript
+// src/worker.ts — identical entrypoint pattern
+
+import { createQueue } from './queue/index.js';
+import { initOrm } from './orm.js';
+import { encryptTraceBody } from './encryption.js';
+import { Trace } from './domain/entities/Trace.js';
+import { Tenant } from './domain/entities/Tenant.js';
+import { Agent } from './domain/entities/Agent.js';
+import { randomUUID } from 'node:crypto';
+import type { TraceEvent } from './queue/types.js';
+
+async function main() {
+  const orm = await initOrm();
+  const em = orm.em;
+  const queue = createQueue(); // QUEUE_DRIVER=azuresb
+  await queue.connect();
+
+  await queue.subscribe(async (event: TraceEvent) => {
+    // Same trace persistence logic as other workers (see section 1b)
+    const { payload: input } = event;
+    const forkedEm = em.fork();
+
+    const reqBodyJson = JSON.stringify(input.requestBody);
+    const { ciphertext: reqCt, iv: reqIv } = encryptTraceBody(input.tenantId, reqBodyJson);
+
+    let resCt: string | null = null;
+    let resIv: string | null = null;
+    if (input.responseBody != null) {
+      const enc = encryptTraceBody(input.tenantId, JSON.stringify(input.responseBody));
+      resCt = enc.ciphertext;
+      resIv = enc.iv;
+    }
+
+    const trace = new Trace();
+    trace.id = event.id;
+    trace.tenant = forkedEm.getReference(Tenant, input.tenantId);
+    trace.agent = input.agentId ? forkedEm.getReference(Agent, input.agentId) : null;
+    trace.requestId = input.requestId ?? randomUUID();
+    trace.model = input.model;
+    trace.provider = input.provider;
+    trace.endpoint = input.endpoint ?? '/v1/chat/completions';
+    trace.requestBody = reqCt;
+    trace.requestIv = reqIv;
+    trace.responseBody = resCt;
+    trace.responseIv = resIv;
+    trace.latencyMs = input.latencyMs;
+    trace.promptTokens = input.promptTokens ?? null;
+    trace.completionTokens = input.completionTokens ?? null;
+    trace.totalTokens = input.totalTokens ?? null;
+    trace.estimatedCostUsd = null;
+    trace.encryptionKeyVersion = 1;
+    trace.statusCode = input.statusCode ?? null;
+    trace.ttfbMs = input.ttfbMs ?? null;
+    trace.gatewayOverheadMs = input.gatewayOverheadMs ?? null;
+    trace.createdAt = new Date(event.timestamp);
+    trace.knowledgeBaseId = input.knowledgeBaseId ?? null;
+    trace.embeddingAgentId = input.embeddingAgentId ?? null;
+    trace.ragRetrievalLatencyMs = input.ragRetrievalLatencyMs ?? null;
+    trace.embeddingLatencyMs = input.embeddingLatencyMs ?? null;
+    trace.vectorSearchLatencyMs = input.vectorSearchLatencyMs ?? null;
+    trace.retrievedChunkCount = input.retrievedChunkCount ?? null;
+    trace.topChunkSimilarity = input.topChunkSimilarity ?? null;
+    trace.avgChunkSimilarity = input.avgChunkSimilarity ?? null;
+    trace.contextTokensAdded = input.contextTokensAdded ?? null;
+    trace.ragOverheadTokens = input.ragOverheadTokens ?? null;
+    trace.ragCostOverheadUsd = input.ragCostOverheadUsd ?? null;
+    trace.ragStageFailed = input.ragStageFailed ?? null;
+    trace.fallbackToNoRag = input.fallbackToNoRag ?? null;
+
+    forkedEm.persist(trace);
+    await forkedEm.flush();
+  });
+
+  console.log('[worker] Listening for trace events...');
+}
+
+main().catch((err) => {
+  console.error('[worker] Fatal:', err);
+  process.exit(1);
+});
+```
+
+### c. Desktop In-Memory Adapter
+
+Same `InMemoryQueue` from section 1c. The Azure Service Bus Emulator exists but requires Docker and the Azure CLI, making it unsuitable for a zero-dependency desktop mode.
+
+### d. Docker Compose Addition
+
+```yaml
+  # Azure Service Bus Emulator (local development only)
+  azurite-servicebus:
+    image: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
+    ports:
+      - "5672:5672"
+    environment:
+      ACCEPT_EULA: "Y"
+      SQL_SERVER: mssql
+    depends_on:
+      mssql:
+        condition: service_healthy
+
+  # The emulator requires SQL Server for state
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "Str0ngP@ssw0rd!"
+    healthcheck:
+      test: /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "Str0ngP@ssw0rd!" -Q "SELECT 1"
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  trace-worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: node dist/worker.js
+    depends_on:
+      azurite-servicebus:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://loom:loom_dev_password@postgres:5432/loom
+      QUEUE_DRIVER: azuresb
+      AZURE_SERVICEBUS_CONNECTION_STRING: "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
+      ENCRYPTION_MASTER_KEY: "0000000000000000000000000000000000000000000000000000000000000001"
+```
+
+### e. Error Handling
+
+Azure Service Bus handles retries via its peek-lock mechanism. If `processMessage` throws, the message lock expires and Service Bus redelivers it. After `maxDeliveryCount` (default: 10) failures, the message moves to the built-in dead-letter sub-queue.
+
+```typescript
+// Configure via Azure portal / CLI / Bicep:
+// Queue properties:
+//   maxDeliveryCount: 5
+//   lockDuration: PT30S (30 seconds)
+//   deadLetteringOnMessageExpiration: true
+
+// Reading from DLQ:
+const dlqReceiver = client.createReceiver(QUEUE_NAME, {
+  subQueueType: 'deadLetter',
+});
+
+const deadLetters = await dlqReceiver.receiveMessages(10, {
+  maxWaitTimeInMs: 5_000,
+});
+
+for (const msg of deadLetters) {
+  console.log('Dead letter reason:', msg.deadLetterReason);
+  console.log('Dead letter description:', msg.deadLetterErrorDescription);
+  // Reprocess or log
+  await dlqReceiver.completeMessage(msg);
+}
+```
+
+**When the worker is down:** Messages accumulate in the queue. Azure Service Bus has configurable max queue size (1-80 GB in Standard/Premium tiers). No risk of data loss. Messages are persisted to Azure-managed storage.
+
+### f. Agent Team Readiness
+
+Azure Service Bus provides sessions (ordered message groups keyed by session ID), which can serve as a building block for saga coordination. Each agent team execution could use a unique session ID to ensure ordered processing. However, there is no built-in saga or workflow engine — orchestration logic would still need to be custom.
+
+Azure Durable Functions (built on Azure Storage) provides saga/workflow support, but that ties the project to Azure Functions as a compute platform, which conflicts with Arachne's self-hosted model.
+
+**Verdict:** Sessions are a useful primitive, but saga support would require significant custom code. Vendor lock-in to Azure is the main concern.
+
+---
+
+## Comparison Matrix
+
+| Dimension | BullMQ | Temporal | RabbitMQ | Azure Service Bus |
+|---|---|---|---|---|
+| **New dependencies** | Redis | Temporal server | RabbitMQ server | Azure subscription or emulator + MSSQL |
+| **Docker image size** | ~30 MB (Redis Alpine) | ~200 MB (Temporal + UI) | ~150 MB (RabbitMQ + mgmt) | ~700 MB (emulator + MSSQL) |
+| **npm packages** | 1 (`bullmq`) | 4 (`@temporalio/*`) | 1 (`amqplib`) | 1 (`@azure/service-bus`) |
+| **Adapter code (LoC)** | ~60 | ~100 (+ workflow file) | ~90 | ~60 |
+| **Publish latency** | < 1ms (Redis XADD) | ~2-5ms (gRPC to Temporal) | < 1ms (AMQP publish) | ~5-15ms (HTTPS to Azure) |
+| **Retry/backoff** | Built-in, configurable | Built-in, declarative | Manual (nack/requeue) | Built-in (peek-lock) |
+| **DLQ** | Built-in (failed set) | N/A (failed workflows) | Manual setup (DLX) | Built-in sub-queue |
+| **Admin UI** | Bull Board (npm add-on) | Temporal UI (excellent) | RabbitMQ Management (built-in) | Azure Portal |
+| **SDK quality (TS)** | Excellent (TS-first) | Excellent (TS-first) | Adequate (callback-based) | Good (Azure SDK) |
+| **Desktop in-memory** | Needs InMemoryQueue | Needs InMemoryQueue | Needs InMemoryQueue | Needs InMemoryQueue |
+| **Saga/workflow** | No (FlowProducer is limited) | Yes (purpose-built) | No | No (sessions help, not enough) |
+| **Operational complexity** | Low (Redis is well-known) | Medium-High (new server) | Medium (Erlang runtime) | Low (managed) / High (emulator) |
+| **Cost (self-hosted)** | Free | Free | Free | ~$0.05/million ops (Standard) |
+| **Community/ecosystem** | Large (npm 1M+/week) | Growing (npm ~100k/week) | Very large (AMQP standard) | Large (Azure ecosystem) |
+
+## Recommendation
+
+**Phase 1 (now): BullMQ**
+
+For the immediate need of durable trace recording, BullMQ is the clear winner on benefit-to-cost ratio:
+
+1. **Minimal infrastructure** — Redis is a single 30 MB container that most teams already run. No new runtime to learn.
+2. **Sub-millisecond publish** — Meets the < 1ms hot-path budget with room to spare. Redis Streams (XADD) is as fast as in-memory operations get for durable writes.
+3. **Batteries included** — Retry with exponential backoff, DLQ, rate limiting, priority queues, and Bull Board UI all work out of the box. No topology to design (unlike RabbitMQ's exchanges) and no retry queue hacks.
+4. **TypeScript-first SDK** — Single package, clean API, well-maintained, massive adoption.
+5. **Small team friendly** — One `docker compose up` and it works. No Erlang runtime, no gRPC servers, no Azure subscriptions.
+
+**Phase 2 (when agent teams ship): Evaluate Temporal**
+
+When multi-agent coordination requires saga/workflow orchestration, Temporal becomes worth its operational cost. At that point:
+
+- The `EventQueue` interface means BullMQ can remain the trace queue backend.
+- Temporal is introduced specifically for agent team workflows (coordinator dispatch, partial failure compensation, timeout management).
+- The two systems coexist: BullMQ for high-throughput fire-and-forget events, Temporal for complex stateful orchestration.
+
+**Why not the others:**
+
+- **RabbitMQ** — Solves the same problem as BullMQ but with more operational complexity (Erlang runtime, exchange topology design, manual DLQ wiring). The AMQP protocol flexibility is not needed here.
+- **Azure Service Bus** — Creates cloud vendor lock-in. The emulator requires MSSQL, which is absurd for a PostgreSQL-native project. Only makes sense if Arachne moves to Azure-managed infrastructure.
+- **Temporal now** — Overengineered for "put trace event in queue, write to database." The 4-package SDK, separate server process, and workflow determinism constraints add complexity that is not justified until we need actual workflow orchestration.
+
+### Migration Path
+
+```
+Phase 1: TraceRecorder (in-memory)     →  BullMQ (Redis)
+         └── QUEUE_DRIVER=memory            └── QUEUE_DRIVER=bullmq
+             (Desktop mode keeps this)          (Server mode)
+
+Phase 2: Agent team orchestration       →  Temporal (alongside BullMQ)
+         └── New workflow engine              └── Trace queue stays on BullMQ
+             for saga coordination                (high throughput, simple)
+```
+
+### Implementation Estimate
+
+| Task | Effort |
+|---|---|
+| Define `EventQueue` interface + factory | 1 hour |
+| `InMemoryQueue` adapter (replaces TraceRecorder) | 2 hours |
+| `BullMQQueue` adapter | 2 hours |
+| Worker entrypoint (`src/worker.ts`) | 2 hours |
+| Extract trace persistence into shared function | 1 hour |
+| Docker Compose (Redis + worker) | 30 min |
+| Update gateway to use `queue.publish()` | 1 hour |
+| Tests (adapter unit + integration) | 3 hours |
+| **Total** | **~1.5 days** |

--- a/migrations/1000000000028_api-key-expiry.cjs
+++ b/migrations/1000000000028_api-key-expiry.cjs
@@ -1,0 +1,31 @@
+/**
+ * Add API key expiry and rotation support.
+ * - expires_at: optional expiration timestamp for API keys
+ * - rotated_from_id: links a new key to the key it replaced
+ * - Partial index on active keys with expiry for efficient expiry checks
+ * @type {import('node-pg-migrate').MigrationBuilder}
+ */
+exports.up = (pgm) => {
+  pgm.addColumns('api_keys', {
+    expires_at: {
+      type: 'timestamptz',
+      notNull: false,
+    },
+    rotated_from_id: {
+      type: 'uuid',
+      notNull: false,
+      references: 'api_keys(id)',
+      onDelete: 'SET NULL',
+    },
+  });
+
+  pgm.createIndex('api_keys', ['expires_at'], {
+    name: 'idx_api_keys_active_expiry',
+    where: "status = 'active' AND expires_at IS NOT NULL",
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropIndex('api_keys', [], { name: 'idx_api_keys_active_expiry' });
+  pgm.dropColumns('api_keys', ['expires_at', 'rotated_from_id']);
+};

--- a/src/application/dtos/agent.dto.ts
+++ b/src/application/dtos/agent.dto.ts
@@ -60,6 +60,10 @@ export interface ApiKeyCreatedViewModel extends ApiKeyViewModel {
   rawKey: string;
 }
 
+export interface ApiKeyRotatedViewModel extends ApiKeyCreatedViewModel {
+  oldKeyHash: string;
+}
+
 export interface CreateApiKeyDto {
   name?: string;
   expiresAt?: string;

--- a/src/application/dtos/agent.dto.ts
+++ b/src/application/dtos/agent.dto.ts
@@ -52,6 +52,8 @@ export interface ApiKeyViewModel {
   createdAt: string;
   agentId: string;
   agentName: string;
+  expiresAt: string | null;
+  rotatedFromId: string | null;
 }
 
 export interface ApiKeyCreatedViewModel extends ApiKeyViewModel {
@@ -60,4 +62,5 @@ export interface ApiKeyCreatedViewModel extends ApiKeyViewModel {
 
 export interface CreateApiKeyDto {
   name?: string;
+  expiresAt?: string;
 }

--- a/src/application/services/AdminService.ts
+++ b/src/application/services/AdminService.ts
@@ -293,6 +293,8 @@ export class AdminService {
       status: 'active',
       createdAt: now,
       rawKey,
+      expiresAt: null,
+      rotatedFromId: null,
     });
     await this.em.persistAndFlush(apiKey);
     return {

--- a/src/application/services/TenantManagementService.ts
+++ b/src/application/services/TenantManagementService.ts
@@ -21,6 +21,7 @@ import type {
   UpdateAgentDto,
   ApiKeyViewModel,
   ApiKeyCreatedViewModel,
+  ApiKeyRotatedViewModel,
   CreateApiKeyDto,
 } from '../dtos/agent.dto.js';
 
@@ -243,7 +244,7 @@ export class TenantManagementService {
     tenantId: string,
     keyId: string,
     dto: CreateApiKeyDto = {},
-  ): Promise<ApiKeyCreatedViewModel> {
+  ): Promise<ApiKeyRotatedViewModel> {
     const oldKey = await this.em.findOneOrFail(
       ApiKey,
       { id: keyId, tenant: tenantId },
@@ -257,7 +258,7 @@ export class TenantManagementService {
     }
     this.em.persist(newKey);
     await this.em.flush();
-    return { ...toApiKeyViewModel(newKey), rawKey };
+    return { ...toApiKeyViewModel(newKey), rawKey, oldKeyHash: oldKey.keyHash };
   }
 
   async revokeApiKey(tenantId: string, keyId: string): Promise<{ keyHash: string }> {

--- a/src/application/services/TenantManagementService.ts
+++ b/src/application/services/TenantManagementService.ts
@@ -67,6 +67,8 @@ function toApiKeyViewModel(k: ApiKey): ApiKeyViewModel {
     createdAt: k.createdAt.toISOString(),
     agentId: (k.agent as any)?.id ?? '',
     agentName: (k.agent as any)?.name ?? '',
+    expiresAt: k.expiresAt ? k.expiresAt.toISOString() : null,
+    rotatedFromId: k.rotatedFromId ?? null,
   };
 }
 
@@ -229,9 +231,33 @@ export class TenantManagementService {
   ): Promise<ApiKeyCreatedViewModel> {
     const agent = await this.em.findOneOrFail(Agent, { id: agentId, tenant: tenantId }, { populate: ['tenant', 'apiKeys'] });
     const { entity: apiKey, rawKey } = agent.createApiKey(dto.name ?? 'Default Key');
+    if (dto.expiresAt) {
+      apiKey.expiresAt = new Date(dto.expiresAt);
+    }
     this.em.persist(apiKey);
     await this.em.flush();
     return { ...toApiKeyViewModel(apiKey), rawKey };
+  }
+
+  async rotateApiKey(
+    tenantId: string,
+    keyId: string,
+    dto: CreateApiKeyDto = {},
+  ): Promise<ApiKeyCreatedViewModel> {
+    const oldKey = await this.em.findOneOrFail(
+      ApiKey,
+      { id: keyId, tenant: tenantId },
+      { populate: ['agent', 'agent.tenant', 'agent.apiKeys'] },
+    );
+    const agent = oldKey.agent as Agent;
+    const { entity: newKey, rawKey } = agent.createApiKey(dto.name ?? oldKey.name);
+    newKey.rotatedFromId = oldKey.id;
+    if (dto.expiresAt) {
+      newKey.expiresAt = new Date(dto.expiresAt);
+    }
+    this.em.persist(newKey);
+    await this.em.flush();
+    return { ...toApiKeyViewModel(newKey), rawKey };
   }
 
   async revokeApiKey(tenantId: string, keyId: string): Promise<{ keyHash: string }> {

--- a/src/application/services/TenantService.ts
+++ b/src/application/services/TenantService.ts
@@ -30,7 +30,7 @@ function resolveArrayChain(arrays: any[][], nameOf: (item: any) => string | unde
 export class TenantService {
   constructor(private readonly em: EntityManager) {}
 
-  async loadByApiKey(rawKey: string): Promise<TenantContext> {
+  async loadByApiKey(rawKey: string): Promise<{ context: TenantContext; expiresAt: Date | null }> {
     const keyHash = createHash('sha256').update(rawKey).digest('hex');
 
     const apiKey = await this.em.findOne(
@@ -40,6 +40,11 @@ export class TenantService {
     );
 
     if (!apiKey) throw new Error('Invalid API key');
+
+    // Check expiry — a non-null expiresAt in the past means the key is expired
+    if (apiKey.expiresAt && apiKey.expiresAt.getTime() < Date.now()) {
+      throw new Error('API key has expired');
+    }
 
     const tenant = apiKey.tenant as Tenant;
     if (tenant.status !== 'active') throw new Error('Tenant is not active');
@@ -114,19 +119,22 @@ export class TenantService {
     };
 
     return {
-      tenantId: tenant.id,
-      name: tenant.name,
-      agentId: agent?.id ?? undefined,
-      knowledgeBaseRef: agent?.knowledgeBaseRef ?? undefined,
-      providerConfig: resolvedProviderConfig,
-      agentSystemPrompt: agent?.systemPrompt ?? undefined,
-      agentSkills: agent?.skills ?? undefined,
-      agentMcpEndpoints: agent?.mcpEndpoints ?? undefined,
-      mergePolicies,
-      resolvedSystemPrompt,
-      resolvedSkills: resolvedSkills.length ? resolvedSkills : undefined,
-      resolvedMcpEndpoints: resolvedMcpEndpoints.length ? resolvedMcpEndpoints : undefined,
-      agentConfig,
+      context: {
+        tenantId: tenant.id,
+        name: tenant.name,
+        agentId: agent?.id ?? undefined,
+        knowledgeBaseRef: agent?.knowledgeBaseRef ?? undefined,
+        providerConfig: resolvedProviderConfig,
+        agentSystemPrompt: agent?.systemPrompt ?? undefined,
+        agentSkills: agent?.skills ?? undefined,
+        agentMcpEndpoints: agent?.mcpEndpoints ?? undefined,
+        mergePolicies,
+        resolvedSystemPrompt,
+        resolvedSkills: resolvedSkills.length ? resolvedSkills : undefined,
+        resolvedMcpEndpoints: resolvedMcpEndpoints.length ? resolvedMcpEndpoints : undefined,
+        agentConfig,
+      },
+      expiresAt: apiKey.expiresAt ?? null,
     };
   }
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -89,8 +89,13 @@ class LRUCache<K, V> {
   }
 }
 
+interface CachedTenant {
+  context: TenantContext;
+  expiresAt: Date | null;
+}
+
 // Shared cache — 1 000 tenants; adjust if tenant count grows significantly
-const tenantCache = new LRUCache<string, TenantContext>(1000);
+const tenantCache = new LRUCache<string, CachedTenant>(1000);
 
 function hashApiKey(rawKey: string): string {
   return createHash('sha256').update(rawKey).digest('hex');
@@ -136,10 +141,22 @@ export function registerAuthMiddleware(fastify: FastifyInstance): void {
     const keyHash = hashApiKey(rawKey);
 
     // LRU cache hit — no DB query needed
-    let tenant = tenantCache.get(keyHash);
+    let cached = tenantCache.get(keyHash);
 
-    if (!tenant) {
-      let found: TenantContext | null = null;
+    // Evict expired keys from cache
+    if (cached && cached.expiresAt && cached.expiresAt.getTime() < Date.now()) {
+      tenantCache.invalidate(keyHash);
+      return reply.code(401).send({
+        error: {
+          message: 'API key has expired.',
+          type: 'invalid_request_error',
+          code: 'expired_api_key',
+        },
+      });
+    }
+
+    if (!cached) {
+      let found: { context: TenantContext; expiresAt: Date | null } | null = null;
       try {
         const tenantService = new TenantService(request.em);
         found = await tenantService.loadByApiKey(rawKey);
@@ -148,11 +165,11 @@ export function registerAuthMiddleware(fastify: FastifyInstance): void {
       }
       if (found) {
         tenantCache.set(keyHash, found);
-        tenant = found;
+        cached = found;
       }
     }
 
-    if (!tenant) {
+    if (!cached) {
       return reply.code(401).send({
         error: {
           message: 'Invalid API key.',
@@ -162,7 +179,7 @@ export function registerAuthMiddleware(fastify: FastifyInstance): void {
       });
     }
 
-    request.tenant = tenant;
+    request.tenant = cached.context;
   });
 }
 

--- a/src/domain/entities/ApiKey.ts
+++ b/src/domain/entities/ApiKey.ts
@@ -11,10 +11,17 @@ export class ApiKey {
   name!: string;
   status!: string;
   revokedAt!: Date | null;
+  expiresAt!: Date | null;
+  rotatedFromId!: string | null;
   createdAt!: Date;
 
   /** Raw key — available immediately after construction, never stored in DB */
   readonly rawKey: string;
+
+  /** Returns true if the key has a non-null expiresAt that is in the past. */
+  isExpired(): boolean {
+    return this.expiresAt !== null && this.expiresAt.getTime() < Date.now();
+  }
 
   constructor(agent: Agent, name: string) {
     const rawKey = 'loom_sk_' + randomBytes(24).toString('base64url');
@@ -26,6 +33,8 @@ export class ApiKey {
     this.name = name;
     this.status = 'active';
     this.revokedAt = null;
+    this.expiresAt = null;
+    this.rotatedFromId = null;
     this.createdAt = new Date();
     this.rawKey = rawKey;
   }

--- a/src/domain/schemas/ApiKey.schema.ts
+++ b/src/domain/schemas/ApiKey.schema.ts
@@ -15,6 +15,8 @@ export const ApiKeySchema = new EntitySchema<ApiKey>({
     name: { type: 'string', columnType: 'varchar(255)', default: 'Default Key' },
     status: { type: 'string', columnType: 'varchar(20)', default: 'active' },
     revokedAt: { type: 'Date', fieldName: 'revoked_at', nullable: true },
+    expiresAt: { type: 'Date', fieldName: 'expires_at', nullable: true },
+    rotatedFromId: { type: 'string', fieldName: 'rotated_from_id', nullable: true },
     createdAt: { type: 'Date', fieldName: 'created_at', onCreate: () => new Date() },
     rawKey: { type: 'string', persist: false },
   },

--- a/src/routes/portal.ts
+++ b/src/routes/portal.ts
@@ -378,6 +378,8 @@ export function registerPortalRoutes(
 
       try {
         const result = await tenantMgmtSvc.rotateApiKey(tenantId, keyId, { name, expiresAt });
+        // Invalidate old key from LRU cache so it must re-authenticate via DB
+        invalidateCachedKey(result.oldKeyHash);
         return reply.code(201).send({
           id: result.id,
           name: result.name,

--- a/src/routes/portal.ts
+++ b/src/routes/portal.ts
@@ -305,18 +305,20 @@ export function registerPortalRoutes(
         createdAt: row.createdAt,
         agentId: row.agentId,
         agentName: row.agentName,
+        expiresAt: row.expiresAt,
+        rotatedFromId: row.rotatedFromId,
       })),
     });
   });
 
   // ── POST /v1/portal/api-keys ──────────────────────────────────────────────
-  fastify.post<{ Body: { name: string; agentId: string } }>(
+  fastify.post<{ Body: { name: string; agentId: string; expiresAt?: string } }>(
     '/v1/portal/api-keys',
     { preHandler: ownerRequired },
     async (request, reply) => {
       const tenantMgmtSvc = new TenantManagementService(request.em);
       const { tenantId } = request.portalUser!;
-      const { name, agentId } = request.body;
+      const { name, agentId, expiresAt } = request.body;
 
       if (!name || typeof name !== 'string' || name.trim().length === 0) {
         return reply.code(400).send({ error: 'API key name is required' });
@@ -325,7 +327,18 @@ export function registerPortalRoutes(
         return reply.code(400).send({ error: 'agentId is required' });
       }
 
-      const result = await tenantMgmtSvc.createApiKey(tenantId, agentId, { name });
+      // Validate expiresAt is a future date if provided
+      if (expiresAt !== undefined) {
+        const parsed = new Date(expiresAt);
+        if (isNaN(parsed.getTime())) {
+          return reply.code(400).send({ error: 'expiresAt must be a valid ISO date string' });
+        }
+        if (parsed.getTime() <= Date.now()) {
+          return reply.code(400).send({ error: 'expiresAt must be a future date' });
+        }
+      }
+
+      const result = await tenantMgmtSvc.createApiKey(tenantId, agentId, { name, expiresAt });
       if (!result) {
         return reply.code(400).send({ error: 'Invalid agentId' });
       }
@@ -337,7 +350,47 @@ export function registerPortalRoutes(
         keyPrefix: result.keyPrefix,
         status: result.status,
         createdAt: result.createdAt,
+        expiresAt: result.expiresAt,
       });
+    },
+  );
+
+  // ── POST /v1/portal/api-keys/:id/rotate ─────────────────────────────────
+  fastify.post<{ Params: { id: string }; Body: { name?: string; expiresAt?: string } }>(
+    '/v1/portal/api-keys/:id/rotate',
+    { preHandler: ownerRequired },
+    async (request, reply) => {
+      const tenantMgmtSvc = new TenantManagementService(request.em);
+      const { tenantId } = request.portalUser!;
+      const { id: keyId } = request.params;
+      const { name, expiresAt } = request.body ?? {};
+
+      // Validate expiresAt is a future date if provided
+      if (expiresAt !== undefined) {
+        const parsed = new Date(expiresAt);
+        if (isNaN(parsed.getTime())) {
+          return reply.code(400).send({ error: 'expiresAt must be a valid ISO date string' });
+        }
+        if (parsed.getTime() <= Date.now()) {
+          return reply.code(400).send({ error: 'expiresAt must be a future date' });
+        }
+      }
+
+      try {
+        const result = await tenantMgmtSvc.rotateApiKey(tenantId, keyId, { name, expiresAt });
+        return reply.code(201).send({
+          id: result.id,
+          name: result.name,
+          key: result.rawKey,
+          keyPrefix: result.keyPrefix,
+          status: result.status,
+          createdAt: result.createdAt,
+          expiresAt: result.expiresAt,
+          rotatedFromId: result.rotatedFromId,
+        });
+      } catch {
+        return reply.code(404).send({ error: 'API key not found' });
+      }
     },
   );
 

--- a/tests/application-services.test.ts
+++ b/tests/application-services.test.ts
@@ -1026,10 +1026,11 @@ describe('TenantService', () => {
 
       const em = buildMockEm({ findOne: vi.fn().mockResolvedValue(apiKeyRecord) });
       const svc = new TenantService(em);
-      const ctx = await svc.loadByApiKey('loom_sk_testkey');
-      expect(ctx.tenantId).toBe('tenant-1');
-      expect(ctx.agentId).toBe('agent-1');
-      expect(ctx.name).toBe('Test Tenant');
+      const result = await svc.loadByApiKey('loom_sk_testkey');
+      expect(result.context.tenantId).toBe('tenant-1');
+      expect(result.context.agentId).toBe('agent-1');
+      expect(result.context.name).toBe('Test Tenant');
+      expect(result.expiresAt).toBeNull();
     });
 
     it('throws "Invalid API key" when key not found', async () => {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -34,7 +34,12 @@ export interface TenantContext {
   keyId: string;
 }
 
-type KeyStore = Map<string, TenantContext>;
+interface CachedTenant {
+  context: TenantContext;
+  expiresAt: Date | null;
+}
+
+type KeyStore = Map<string, { context: TenantContext; expiresAt: Date | null }>;
 
 /** Minimal LRU cache (bounded Map using insertion-order eviction). */
 class LRUCache<K, V> {
@@ -65,6 +70,10 @@ class LRUCache<K, V> {
     this.lookupCount.set(key, 0);
   }
 
+  invalidate(key: K): void {
+    this.cache.delete(key);
+  }
+
   hits(key: K): number {
     return this.lookupCount.get(key) ?? 0;
   }
@@ -88,7 +97,7 @@ class LRUCache<K, V> {
 function buildAuthGateway(
   port: number,
   keyStore: KeyStore,
-  lruCache: LRUCache<string, TenantContext>
+  lruCache: LRUCache<string, CachedTenant>
 ): FastifyInstance {
   const app = Fastify({ logger: false });
 
@@ -114,19 +123,30 @@ function buildAuthGateway(
     }
 
     // Check LRU cache first
-    let tenant = lruCache.get(apiKey);
-    if (!tenant) {
+    let cached = lruCache.get(apiKey);
+
+    // Evict expired keys from cache
+    if (cached && cached.expiresAt && cached.expiresAt.getTime() < Date.now()) {
+      lruCache.invalidate(apiKey);
+      return reply.code(401).send({ error: { message: 'API key has expired', type: 'auth_error', code: 'expired_api_key' } });
+    }
+
+    if (!cached) {
       // Fall back to key store (simulates DB lookup in real impl)
       const stored = keyStore.get(apiKey);
       if (!stored) {
         return reply.code(401).send({ error: { message: 'Invalid API key', type: 'auth_error' } });
       }
-      tenant = stored;
-      lruCache.set(apiKey, tenant);
+      // Check expiry on initial load (mirrors TenantService.loadByApiKey behavior)
+      if (stored.expiresAt && stored.expiresAt.getTime() < Date.now()) {
+        return reply.code(401).send({ error: { message: 'API key has expired', type: 'auth_error', code: 'expired_api_key' } });
+      }
+      cached = stored;
+      lruCache.set(apiKey, cached);
     }
 
     // Attach tenant context to request
-    (request as any).tenant = tenant;
+    (request as any).tenant = cached.context;
   });
 
   // Echo endpoint — returns the tenant context attached by auth middleware
@@ -142,17 +162,21 @@ function buildAuthGateway(
 const VALID_KEY = 'sk-loom-valid-key-abc123';
 const VALID_KEY_2 = 'sk-loom-valid-key-def456';
 const INVALID_KEY = 'sk-loom-bogus-key-xyz';
+const EXPIRED_KEY = 'sk-loom-expired-key-ghi789';
+const FUTURE_EXPIRY_KEY = 'sk-loom-future-expiry-jkl012';
 
 const keyStore: KeyStore = new Map([
-  [VALID_KEY, { tenantId: 'tenant-001', keyId: 'key-001' }],
-  [VALID_KEY_2, { tenantId: 'tenant-002', keyId: 'key-002' }],
+  [VALID_KEY, { context: { tenantId: 'tenant-001', keyId: 'key-001' }, expiresAt: null }],
+  [VALID_KEY_2, { context: { tenantId: 'tenant-002', keyId: 'key-002' }, expiresAt: null }],
+  [EXPIRED_KEY, { context: { tenantId: 'tenant-003', keyId: 'key-003' }, expiresAt: new Date(Date.now() - 60_000) }],
+  [FUTURE_EXPIRY_KEY, { context: { tenantId: 'tenant-004', keyId: 'key-004' }, expiresAt: new Date(Date.now() + 86_400_000) }],
 ]);
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 describe('auth — valid key passes through with tenant context', () => {
   let app: FastifyInstance;
-  let lru: LRUCache<string, TenantContext>;
+  let lru: LRUCache<string, CachedTenant>;
 
   beforeAll(async () => {
     lru = new LRUCache(100);
@@ -213,7 +237,7 @@ describe('auth — invalid or missing key returns 401', () => {
   let app: FastifyInstance;
 
   beforeAll(async () => {
-    const lru = new LRUCache<string, TenantContext>(100);
+    const lru = new LRUCache<string, CachedTenant>(100);
     app = buildAuthGateway(3022, keyStore, lru);
     await app.listen({ port: 3022, host: '127.0.0.1' });
   });
@@ -291,7 +315,7 @@ describe('auth — invalid or missing key returns 401', () => {
 
 describe('auth — LRU cache behaviour', () => {
   let app: FastifyInstance;
-  let lru: LRUCache<string, TenantContext>;
+  let lru: LRUCache<string, CachedTenant>;
 
   beforeAll(async () => {
     lru = new LRUCache(100);
@@ -337,8 +361,8 @@ describe('auth — LRU cache behaviour', () => {
   });
 
   it('cache evicts oldest entry when max size is reached', () => {
-    const tinyCache = new LRUCache<string, TenantContext>(2);
-    const ctx = (id: string): TenantContext => ({ tenantId: id, keyId: id });
+    const tinyCache = new LRUCache<string, CachedTenant>(2);
+    const ctx = (id: string): CachedTenant => ({ context: { tenantId: id, keyId: id }, expiresAt: null });
 
     tinyCache.set('key-a', ctx('a'));
     tinyCache.set('key-b', ctx('b'));
@@ -352,8 +376,8 @@ describe('auth — LRU cache behaviour', () => {
   });
 
   it('accessing a key should refresh its LRU position (most-recently-used stays)', () => {
-    const tinyCache = new LRUCache<string, TenantContext>(2);
-    const ctx = (id: string): TenantContext => ({ tenantId: id, keyId: id });
+    const tinyCache = new LRUCache<string, CachedTenant>(2);
+    const ctx = (id: string): CachedTenant => ({ context: { tenantId: id, keyId: id }, expiresAt: null });
 
     tinyCache.set('key-a', ctx('a'));
     tinyCache.set('key-b', ctx('b'));
@@ -374,7 +398,7 @@ describe('auth — multi-tenant isolation', () => {
   let app: FastifyInstance;
 
   beforeAll(async () => {
-    const lru = new LRUCache<string, TenantContext>(100);
+    const lru = new LRUCache<string, CachedTenant>(100);
     app = buildAuthGateway(3024, keyStore, lru);
     await app.listen({ port: 3024, host: '127.0.0.1' });
   });
@@ -401,5 +425,77 @@ describe('auth — multi-tenant isolation', () => {
 
     expect(data1.tenant.tenantId).not.toBe(data2.tenant.tenantId);
     expect(data1.tenant.keyId).not.toBe(data2.tenant.keyId);
+  });
+});
+
+describe('auth — API key expiry', () => {
+  let app: FastifyInstance;
+  let lru: LRUCache<string, CachedTenant>;
+
+  beforeAll(async () => {
+    lru = new LRUCache(100);
+    app = buildAuthGateway(3025, keyStore, lru);
+    await app.listen({ port: 3025, host: '127.0.0.1' });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('expired key should return 401 with expired_api_key code', async () => {
+    const res = await fetch('http://127.0.0.1:3025/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'x-api-key': EXPIRED_KEY },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error.code).toBe('expired_api_key');
+    expect(data.error.message).toContain('expired');
+  });
+
+  it('key with future expiresAt should pass through normally', async () => {
+    const res = await fetch('http://127.0.0.1:3025/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'x-api-key': FUTURE_EXPIRY_KEY },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.tenant.tenantId).toBe('tenant-004');
+  });
+
+  it('key with null expiresAt (never expires) should pass through', async () => {
+    const res = await fetch('http://127.0.0.1:3025/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'x-api-key': VALID_KEY },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.tenant.tenantId).toBe('tenant-001');
+  });
+
+  it('expired key in cache should be evicted and return 401', async () => {
+    // Pre-populate cache with an expired entry
+    const expiredCached: CachedTenant = {
+      context: { tenantId: 'tenant-cached-expired', keyId: 'key-cached-expired' },
+      expiresAt: new Date(Date.now() - 1000),
+    };
+    lru.set('sk-cached-expired', expiredCached);
+    expect(lru.size()).toBeGreaterThan(0);
+
+    const res = await fetch('http://127.0.0.1:3025/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'x-api-key': 'sk-cached-expired' },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error.code).toBe('expired_api_key');
   });
 });

--- a/tests/portal-routes.test.ts
+++ b/tests/portal-routes.test.ts
@@ -131,7 +131,7 @@ function buildMockTenantMgmtSvc(): TenantManagementService {
     rotateApiKey: vi.fn().mockResolvedValue({
       id: 'new-key-uuid', name: 'Test Key', keyPrefix: 'loom_new_', status: 'active',
       createdAt: new Date().toISOString(), rawKey: 'loom_new_secret', agentId: TEST_AGENT_ID, agentName: TEST_AGENT_NAME,
-      expiresAt: null, rotatedFromId: 'key-uuid',
+      expiresAt: null, rotatedFromId: 'key-uuid', oldKeyHash: 'old-key-hash-123',
     }),
     createAgent: vi.fn().mockImplementation((tenantId: string, dto: any) => Promise.resolve({
       id: 'new-agent-id', tenantId, name: dto.name, providerConfig: dto.providerConfig,

--- a/tests/portal-routes.test.ts
+++ b/tests/portal-routes.test.ts
@@ -125,8 +125,14 @@ function buildMockTenantMgmtSvc(): TenantManagementService {
     createApiKey: vi.fn().mockResolvedValue({
       id: 'key-uuid', name: 'Test Key', keyPrefix: 'loom_test', status: 'active',
       createdAt: new Date().toISOString(), rawKey: 'loom_test_secret', agentId: TEST_AGENT_ID, agentName: TEST_AGENT_NAME,
+      expiresAt: null, rotatedFromId: null,
     }),
     revokeApiKey: vi.fn().mockResolvedValue({ keyHash: 'hash123' }),
+    rotateApiKey: vi.fn().mockResolvedValue({
+      id: 'new-key-uuid', name: 'Test Key', keyPrefix: 'loom_new_', status: 'active',
+      createdAt: new Date().toISOString(), rawKey: 'loom_new_secret', agentId: TEST_AGENT_ID, agentName: TEST_AGENT_NAME,
+      expiresAt: null, rotatedFromId: 'key-uuid',
+    }),
     createAgent: vi.fn().mockImplementation((tenantId: string, dto: any) => Promise.resolve({
       id: 'new-agent-id', tenantId, name: dto.name, providerConfig: dto.providerConfig,
       systemPrompt: dto.systemPrompt, skills: dto.skills, mcpEndpoints: dto.mcpEndpoints,
@@ -825,6 +831,225 @@ describe('PATCH /v1/portal/settings (org name & slug)', () => {
       url: '/v1/portal/settings',
       headers: { authorization: `Bearer ${authToken(TEST_USER_ID, TEST_TENANT_ID, 'member')}` },
       payload: { name: 'Test' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+// ── POST /v1/portal/api-keys (with expiresAt) ──────────────────────────────
+
+describe('POST /v1/portal/api-keys (with expiresAt)', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    process.env.ENCRYPTION_MASTER_KEY = TEST_MASTER_KEY;
+    app = await buildApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    delete process.env.ENCRYPTION_MASTER_KEY;
+  });
+
+  it('creates API key with expiresAt and returns it in the response', async () => {
+    const futureDate = new Date(Date.now() + 86_400_000).toISOString();
+    const tenantMgmtSvc = buildMockTenantMgmtSvc();
+    (tenantMgmtSvc.createApiKey as any).mockResolvedValue({
+      id: 'key-uuid', name: 'Expiring Key', keyPrefix: 'loom_test', status: 'active',
+      createdAt: new Date().toISOString(), rawKey: 'loom_test_secret',
+      agentId: TEST_AGENT_ID, agentName: TEST_AGENT_NAME,
+      expiresAt: futureDate, rotatedFromId: null,
+    });
+    const localApp = await buildApp(buildMockPortalSvc(), buildMockConvSvc(), buildMockUserMgmtSvc(), tenantMgmtSvc);
+
+    const res = await localApp.inject({
+      method: 'POST',
+      url: '/v1/portal/api-keys',
+      headers: { authorization: `Bearer ${authToken()}` },
+      payload: { name: 'Expiring Key', agentId: TEST_AGENT_ID, expiresAt: futureDate },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.expiresAt).toBe(futureDate);
+    expect(tenantMgmtSvc.createApiKey).toHaveBeenCalledWith(
+      TEST_TENANT_ID, TEST_AGENT_ID,
+      { name: 'Expiring Key', expiresAt: futureDate },
+    );
+    await localApp.close();
+  });
+
+  it('rejects expiresAt in the past with 400', async () => {
+    const pastDate = new Date(Date.now() - 60_000).toISOString();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/portal/api-keys',
+      headers: { authorization: `Bearer ${authToken()}` },
+      payload: { name: 'Expired Key', agentId: TEST_AGENT_ID, expiresAt: pastDate },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain('future date');
+  });
+
+  it('rejects invalid expiresAt format with 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/portal/api-keys',
+      headers: { authorization: `Bearer ${authToken()}` },
+      payload: { name: 'Bad Date', agentId: TEST_AGENT_ID, expiresAt: 'not-a-date' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain('valid ISO date');
+  });
+});
+
+// ── GET /v1/portal/api-keys (includes expiry fields) ────────────────────────
+
+describe('GET /v1/portal/api-keys (includes expiry fields)', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    process.env.ENCRYPTION_MASTER_KEY = TEST_MASTER_KEY;
+    const tenantMgmtSvc = buildMockTenantMgmtSvc();
+    (tenantMgmtSvc.listApiKeys as any).mockResolvedValue([
+      {
+        id: 'key-1', name: 'Key One', keyPrefix: 'loom_test', status: 'active',
+        createdAt: new Date().toISOString(), agentId: TEST_AGENT_ID, agentName: TEST_AGENT_NAME,
+        expiresAt: '2027-01-01T00:00:00.000Z', rotatedFromId: null,
+      },
+      {
+        id: 'key-2', name: 'Key Two', keyPrefix: 'loom_test2', status: 'active',
+        createdAt: new Date().toISOString(), agentId: TEST_AGENT_ID, agentName: TEST_AGENT_NAME,
+        expiresAt: null, rotatedFromId: 'key-1',
+      },
+    ]);
+    app = await buildApp(buildMockPortalSvc(), buildMockConvSvc(), buildMockUserMgmtSvc(), tenantMgmtSvc);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    delete process.env.ENCRYPTION_MASTER_KEY;
+  });
+
+  it('includes expiresAt and rotatedFromId in response', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/portal/api-keys',
+      headers: { authorization: `Bearer ${authToken()}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.apiKeys).toHaveLength(2);
+    expect(body.apiKeys[0].expiresAt).toBe('2027-01-01T00:00:00.000Z');
+    expect(body.apiKeys[0].rotatedFromId).toBeNull();
+    expect(body.apiKeys[1].expiresAt).toBeNull();
+    expect(body.apiKeys[1].rotatedFromId).toBe('key-1');
+  });
+});
+
+// ── POST /v1/portal/api-keys/:id/rotate ─────────────────────────────────────
+
+describe('POST /v1/portal/api-keys/:id/rotate', () => {
+  let app: FastifyInstance;
+  let tenantMgmtSvc: TenantManagementService;
+
+  beforeEach(async () => {
+    process.env.ENCRYPTION_MASTER_KEY = TEST_MASTER_KEY;
+    tenantMgmtSvc = buildMockTenantMgmtSvc();
+    app = await buildApp(buildMockPortalSvc(), buildMockConvSvc(), buildMockUserMgmtSvc(), tenantMgmtSvc);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    delete process.env.ENCRYPTION_MASTER_KEY;
+  });
+
+  it('creates a new key linked to the old key via rotatedFromId', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/portal/api-keys/key-uuid/rotate',
+      headers: { authorization: `Bearer ${authToken()}` },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.id).toBe('new-key-uuid');
+    expect(body.key).toBe('loom_new_secret');
+    expect(body.rotatedFromId).toBe('key-uuid');
+    expect(tenantMgmtSvc.rotateApiKey).toHaveBeenCalledWith(
+      TEST_TENANT_ID, 'key-uuid',
+      { name: undefined, expiresAt: undefined },
+    );
+  });
+
+  it('accepts optional name and expiresAt for the new key', async () => {
+    const futureDate = new Date(Date.now() + 86_400_000).toISOString();
+    (tenantMgmtSvc.rotateApiKey as any).mockResolvedValue({
+      id: 'rotated-key', name: 'Custom Name', keyPrefix: 'loom_rot_', status: 'active',
+      createdAt: new Date().toISOString(), rawKey: 'loom_rotated_secret',
+      agentId: TEST_AGENT_ID, agentName: TEST_AGENT_NAME,
+      expiresAt: futureDate, rotatedFromId: 'key-uuid',
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/portal/api-keys/key-uuid/rotate',
+      headers: { authorization: `Bearer ${authToken()}` },
+      payload: { name: 'Custom Name', expiresAt: futureDate },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.name).toBe('Custom Name');
+    expect(body.expiresAt).toBe(futureDate);
+  });
+
+  it('returns 404 when old key does not exist', async () => {
+    (tenantMgmtSvc.rotateApiKey as any).mockRejectedValue(new Error('not found'));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/portal/api-keys/nonexistent-id/rotate',
+      headers: { authorization: `Bearer ${authToken()}` },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toContain('API key not found');
+  });
+
+  it('returns 400 when expiresAt is in the past', async () => {
+    const pastDate = new Date(Date.now() - 60_000).toISOString();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/portal/api-keys/key-uuid/rotate',
+      headers: { authorization: `Bearer ${authToken()}` },
+      payload: { expiresAt: pastDate },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain('future date');
+  });
+
+  it('returns 401 without auth token', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/portal/api-keys/key-uuid/rotate',
+      payload: {},
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 403 for non-owner', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/portal/api-keys/key-uuid/rotate',
+      headers: { authorization: `Bearer ${authToken(TEST_USER_ID, TEST_TENANT_ID, 'member')}` },
+      payload: {},
     });
     expect(res.statusCode).toBe(403);
   });


### PR DESCRIPTION
## Summary
- Add `expires_at` and `rotated_from_id` columns to `api_keys` table with partial index
- Auth middleware checks expiry on LRU cache hit — single Date comparison, zero DB overhead
- Distinct `expired_api_key` error code so clients can differentiate expired from invalid
- `TenantService.loadByApiKey` returns `{ context, expiresAt }` for cache-aware expiry
- New `POST /v1/portal/api-keys/:id/rotate` endpoint — creates replacement key linked to old, does NOT auto-revoke (grace period for rollover)
- Key creation accepts optional `expiresAt` (ISO 8601, validated as future date)
- `null` expiresAt = never expires (backward compatible, no existing keys affected)

## Files changed
- Migration: `1000000000028_api-key-expiry.cjs`
- Entity/Schema: `ApiKey.ts`, `ApiKey.schema.ts`
- Auth: `auth.ts` (CachedTenant type, expiry check)
- Services: `TenantService.ts`, `TenantManagementService.ts`, `AdminService.ts`
- Routes: `portal.ts` (create, list, rotate endpoints)
- Tests: `auth.test.ts` (4 new), `portal-routes.test.ts` (10 new), `application-services.test.ts` (updated)

## Test plan
- [x] TypeScript compiles clean
- [x] All new tests pass (auth expiry, rotation, validation)
- [x] Existing tests updated for new loadByApiKey return type
- [ ] Manual test: create key with expiry, verify rejection after expiry
- [ ] Manual test: rotate key, verify both work during grace period

🤖 Generated with [Claude Code](https://claude.com/claude-code)