### PR TITLE
fix: extract agent system prompt from bundle at deploy time

### DIFF
--- a/src/lib/tar.ts
+++ b/src/lib/tar.ts
@@ -1,0 +1,43 @@
+/**
+ * Minimal tar reader for .orb bundles.
+ * No external dependencies: uses only Node built-ins.
+ */
+
+/**
+ * Extract a single file from a raw tar buffer by name.
+ * Returns null if the file is not found.
+ */
+export function extractFileFromTar(tarBuf: Buffer, targetName: string): Buffer | null {
+  let offset = 0;
+
+  while (offset + 512 <= tarBuf.length) {
+    const header = tarBuf.subarray(offset, offset + 512);
+
+    // Check for end-of-archive (all zeros)
+    let allZero = true;
+    for (let i = 0; i < 512; i++) {
+      if (header[i] !== 0) { allZero = false; break; }
+    }
+    if (allZero) break;
+
+    // Read name (null-terminated, up to 100 bytes)
+    let nameEnd = 0;
+    while (nameEnd < 100 && header[nameEnd] !== 0) nameEnd++;
+    const name = header.toString('utf8', 0, nameEnd);
+
+    // Read size (octal, at offset 124, 12 bytes)
+    const sizeStr = header.toString('ascii', 124, 136).replace(/\0/g, '').trim();
+    const size = parseInt(sizeStr, 8) || 0;
+
+    const dataStart = offset + 512;
+    const paddedSize = Math.ceil(size / 512) * 512;
+
+    if (name === targetName) {
+      return tarBuf.subarray(dataStart, dataStart + size);
+    }
+
+    offset = dataStart + paddedSize;
+  }
+
+  return null;
+}

--- a/src/lib/yaml.ts
+++ b/src/lib/yaml.ts
@@ -1,0 +1,57 @@
+/**
+ * Minimal YAML parser for Arachne spec files.
+ * Handles simple key-value pairs and nested objects.
+ * Does NOT handle arrays, block scalars (|, >), or advanced YAML features.
+ */
+
+function parseYamlValue(raw: string): string | number | boolean | null {
+  const stripped = raw.indexOf(' #') > 0 ? raw.slice(0, raw.indexOf(' #')).trim() : raw;
+  if (stripped === 'true') return true;
+  if (stripped === 'false') return false;
+  if (stripped === 'null' || stripped === '~') return null;
+  if (
+    (stripped.startsWith('"') && stripped.endsWith('"')) ||
+    (stripped.startsWith("'") && stripped.endsWith("'"))
+  ) {
+    return stripped.slice(1, -1);
+  }
+  if (/^-?\d+(\.\d+)?$/.test(stripped)) return Number(stripped);
+  return stripped;
+}
+
+export function parseSimpleYaml(content: string): Record<string, unknown> {
+  const root: Record<string, unknown> = {};
+  const stack: Array<{ obj: Record<string, unknown>; indent: number }> = [
+    { obj: root, indent: -1 },
+  ];
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trimStart();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const indent = line.length - trimmed.length;
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx === -1) continue;
+
+    const key = trimmed.slice(0, colonIdx).trim();
+    const rawValue = trimmed.slice(colonIdx + 1).trim();
+
+    // Pop stack until we find the correct parent scope
+    while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
+      stack.pop();
+    }
+
+    const parent = stack[stack.length - 1].obj;
+
+    if (!rawValue || rawValue.startsWith('#')) {
+      // Nested object
+      const nested: Record<string, unknown> = {};
+      parent[key] = nested;
+      stack.push({ obj: nested, indent });
+    } else {
+      parent[key] = parseYamlValue(rawValue);
+    }
+  }
+
+  return root;
+}

--- a/src/services/ProvisionService.ts
+++ b/src/services/ProvisionService.ts
@@ -6,7 +6,7 @@ import { REGISTRY_SCOPES } from '../auth/registryScopes.js';
 import { RUNTIME_JWT_SECRET } from '../auth/secrets.js';
 import { RegistryService } from './RegistryService.js';
 import { extractFileFromTar } from '../lib/tar.js';
-import { parseSimpleYaml } from './WeaveService.js';
+import { parseSimpleYaml } from '../lib/yaml.js';
 import { Deployment } from '../domain/entities/Deployment.js';
 import { Tenant } from '../domain/entities/Tenant.js';
 import { Artifact } from '../domain/entities/Artifact.js';
@@ -185,7 +185,9 @@ export function extractAgentMetadata(
 ): Record<string, unknown> | null {
   if (!artifact.bundleData || artifact.bundleData.length === 0) return null;
 
-  const tarBuf = gunzipSync(artifact.bundleData);
+  // Cap decompressed size at 50 MB to prevent OOM from crafted bundles
+  const MAX_DECOMPRESSED_SIZE = 50 * 1024 * 1024;
+  const tarBuf = gunzipSync(artifact.bundleData, { maxOutputLength: MAX_DECOMPRESSED_SIZE });
 
   // Try spec.json first (structured JSON from server-side weave)
   const specJsonBuf = extractFileFromTar(tarBuf, 'spec.json');
@@ -263,15 +265,28 @@ function extractYamlBlockScalar(yaml: string, key: string): string | null {
     const lineIndent = line.length - line.trimStart().length;
     if (lineIndent <= baseIndent) break; // Dedented: end of block
 
-    collected.push(line.trimStart());
+    collected.push(line);
   }
 
   if (collected.length === 0) return null;
 
+  // Strip common indentation (preserve relative indentation within block)
+  let minIndent = Infinity;
+  for (const line of collected) {
+    if (line === '') continue;
+    const indent = line.length - line.trimStart().length;
+    if (indent < minIndent) minIndent = indent;
+  }
+  if (!isFinite(minIndent)) minIndent = 0;
+
+  const normalized = collected.map((line) =>
+    line === '' ? '' : line.slice(minIndent),
+  );
+
   // Trim trailing empty lines
-  while (collected.length > 0 && collected[collected.length - 1] === '') {
-    collected.pop();
+  while (normalized.length > 0 && normalized[normalized.length - 1] === '') {
+    normalized.pop();
   }
 
-  return collected.join('\n');
+  return normalized.join('\n');
 }

--- a/src/services/ProvisionService.ts
+++ b/src/services/ProvisionService.ts
@@ -1,11 +1,15 @@
 import { randomUUID } from 'node:crypto';
+import { gunzipSync } from 'node:zlib';
 import type { EntityManager } from '@mikro-orm/core';
 import { signJwt } from '../auth/jwtUtils.js';
 import { REGISTRY_SCOPES } from '../auth/registryScopes.js';
 import { RUNTIME_JWT_SECRET } from '../auth/secrets.js';
 import { RegistryService } from './RegistryService.js';
+import { extractFileFromTar } from '../lib/tar.js';
+import { parseSimpleYaml } from './WeaveService.js';
 import { Deployment } from '../domain/entities/Deployment.js';
 import { Tenant } from '../domain/entities/Tenant.js';
+import { Artifact } from '../domain/entities/Artifact.js';
 import { KbChunk } from '../domain/entities/KbChunk.js';
 
 const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
@@ -46,6 +50,22 @@ export class ProvisionService {
         status: 'FAILED',
         errorMessage: 'Artifact not found',
       };
+    }
+
+    // 2b. Hydrate artifact metadata from bundle if not already populated
+    if (
+      (artifact.kind === 'Agent' || artifact.kind === 'EmbeddingAgent') &&
+      Object.keys(artifact.metadata ?? {}).length === 0
+    ) {
+      try {
+        const extracted = extractAgentMetadata(artifact);
+        if (extracted) {
+          artifact.metadata = extracted;
+          // flush later with the deployment persist
+        }
+      } catch (err) {
+        console.warn('[provision] failed to extract metadata from bundle:', err);
+      }
     }
 
     // 3. Create Deployment entity with status PENDING
@@ -147,4 +167,111 @@ export class ProvisionService {
       { populate: ['artifact'], orderBy: { createdAt: 'DESC' } },
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Bundle metadata extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract agent metadata from the artifact's .orb bundle.
+ *
+ * Tries `spec.json` first (server-side WeaveService format), then falls back
+ * to `spec.yaml` (CLI weave format). Returns null if neither is found or
+ * the spec doesn't contain relevant metadata.
+ */
+export function extractAgentMetadata(
+  artifact: Artifact,
+): Record<string, unknown> | null {
+  if (!artifact.bundleData || artifact.bundleData.length === 0) return null;
+
+  const tarBuf = gunzipSync(artifact.bundleData);
+
+  // Try spec.json first (structured JSON from server-side weave)
+  const specJsonBuf = extractFileFromTar(tarBuf, 'spec.json');
+  if (specJsonBuf) {
+    const parsed = JSON.parse(specJsonBuf.toString('utf8'));
+    const spec = parsed.spec ?? parsed;
+    return buildMetadata(spec);
+  }
+
+  // Fall back to spec.yaml (CLI weave format)
+  const specYamlBuf = extractFileFromTar(tarBuf, 'spec.yaml');
+  if (specYamlBuf) {
+    const parsed = parseSimpleYaml(specYamlBuf.toString('utf8'));
+    const spec = (parsed.spec ?? parsed) as Record<string, unknown>;
+
+    // parseSimpleYaml can't handle YAML block scalars (|), so extract
+    // systemPrompt via targeted regex if the parser only captured "|"
+    if (spec.systemPrompt === '|' || spec.systemPrompt === undefined) {
+      const yamlText = specYamlBuf.toString('utf8');
+      const blockPrompt = extractYamlBlockScalar(yamlText, 'systemPrompt');
+      if (blockPrompt) {
+        spec.systemPrompt = blockPrompt;
+      }
+    }
+
+    return buildMetadata(spec);
+  }
+
+  return null;
+}
+
+function buildMetadata(spec: Record<string, unknown>): Record<string, unknown> | null {
+  const meta: Record<string, unknown> = {};
+
+  if (spec.systemPrompt != null) meta.systemPrompt = spec.systemPrompt;
+  if (spec.model != null) meta.model = spec.model;
+  if (spec.knowledgeBaseRef != null) meta.knowledgeBaseRef = spec.knowledgeBaseRef;
+  if (spec.conversationsEnabled != null) meta.conversations_enabled = spec.conversationsEnabled;
+  if (spec.conversations_enabled != null) meta.conversations_enabled = spec.conversations_enabled;
+  if (spec.conversationTokenLimit != null) meta.conversation_token_limit = spec.conversationTokenLimit;
+  if (spec.conversation_token_limit != null) meta.conversation_token_limit = spec.conversation_token_limit;
+  if (spec.temperature != null) meta.temperature = spec.temperature;
+  if (spec.maxTokens != null) meta.maxTokens = spec.maxTokens;
+
+  return Object.keys(meta).length > 0 ? meta : null;
+}
+
+/**
+ * Extract a YAML block scalar value (lines after `key: |` that are indented
+ * deeper than the key). Returns null if not found.
+ */
+function extractYamlBlockScalar(yaml: string, key: string): string | null {
+  const lines = yaml.split('\n');
+  const pattern = new RegExp(`^(\\s*)${key}:\\s*\\|\\s*$`);
+  let collecting = false;
+  let baseIndent = 0;
+  const collected: string[] = [];
+
+  for (const line of lines) {
+    if (!collecting) {
+      const match = line.match(pattern);
+      if (match) {
+        collecting = true;
+        baseIndent = match[1].length;
+      }
+      continue;
+    }
+
+    // Empty lines are preserved in block scalars
+    if (line.trim() === '') {
+      collected.push('');
+      continue;
+    }
+
+    const lineIndent = line.length - line.trimStart().length;
+    if (lineIndent <= baseIndent) break; // Dedented: end of block
+
+    collected.push(line.trimStart());
+  }
+
+  if (collected.length === 0) return null;
+
+  // Trim trailing empty lines
+  while (collected.length > 0 && collected[collected.length - 1] === '') {
+    collected.pop();
+  }
+
+  return collected.join('\n');
 }

--- a/src/services/ProvisionService.ts
+++ b/src/services/ProvisionService.ts
@@ -240,7 +240,7 @@ function buildMetadata(spec: Record<string, unknown>): Record<string, unknown> |
  * deeper than the key). Returns null if not found.
  */
 function extractYamlBlockScalar(yaml: string, key: string): string | null {
-  const lines = yaml.split('\n');
+  const lines = yaml.split(/\r?\n/);
   const pattern = new RegExp(`^(\\s*)${key}:\\s*\\|\\s*$`);
   let collecting = false;
   let baseIndent = 0;

--- a/src/services/WeaveService.ts
+++ b/src/services/WeaveService.ts
@@ -55,59 +55,10 @@ export interface WeaveResult {
   vectorSpaceId?: string;
 }
 
-// ─── Minimal YAML Parser ─────────────────────────────────────────────────────
+// ─── YAML Parser (re-exported from src/lib/yaml.ts) ─────────────────────────
 
-function parseYamlValue(raw: string): string | number | boolean | null {
-  const stripped = raw.indexOf(' #') > 0 ? raw.slice(0, raw.indexOf(' #')).trim() : raw;
-  if (stripped === 'true') return true;
-  if (stripped === 'false') return false;
-  if (stripped === 'null' || stripped === '~') return null;
-  if (
-    (stripped.startsWith('"') && stripped.endsWith('"')) ||
-    (stripped.startsWith("'") && stripped.endsWith("'"))
-  ) {
-    return stripped.slice(1, -1);
-  }
-  if (/^-?\d+(\.\d+)?$/.test(stripped)) return Number(stripped);
-  return stripped;
-}
-
-export function parseSimpleYaml(content: string): Record<string, unknown> {
-  const root: Record<string, unknown> = {};
-  const stack: Array<{ obj: Record<string, unknown>; indent: number }> = [
-    { obj: root, indent: -1 },
-  ];
-
-  for (const line of content.split('\n')) {
-    const trimmed = line.trimStart();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-
-    const indent = line.length - trimmed.length;
-    const colonIdx = trimmed.indexOf(':');
-    if (colonIdx === -1) continue;
-
-    const key = trimmed.slice(0, colonIdx).trim();
-    const rawValue = trimmed.slice(colonIdx + 1).trim();
-
-    // Pop stack until we find the correct parent scope
-    while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
-      stack.pop();
-    }
-
-    const parent = stack[stack.length - 1].obj;
-
-    if (!rawValue || rawValue.startsWith('#')) {
-      // Nested object
-      const nested: Record<string, unknown> = {};
-      parent[key] = nested;
-      stack.push({ obj: nested, indent });
-    } else {
-      parent[key] = parseYamlValue(rawValue);
-    }
-  }
-
-  return root;
-}
+import { parseSimpleYaml } from '../lib/yaml.js';
+export { parseSimpleYaml };
 
 // ─── Minimal tar Builder ─────────────────────────────────────────────────────
 

--- a/src/services/WeaveService.ts
+++ b/src/services/WeaveService.ts
@@ -72,7 +72,7 @@ function parseYamlValue(raw: string): string | number | boolean | null {
   return stripped;
 }
 
-function parseSimpleYaml(content: string): Record<string, unknown> {
+export function parseSimpleYaml(content: string): Record<string, unknown> {
   const root: Record<string, unknown> = {};
   const stack: Array<{ obj: Record<string, unknown>; indent: number }> = [
     { obj: root, indent: -1 },

--- a/tests/registry-services.test.ts
+++ b/tests/registry-services.test.ts
@@ -8,7 +8,7 @@ import { gzipSync } from 'node:zlib';
 import type { EntityManager } from '@mikro-orm/core';
 import { WeaveService } from '../src/services/WeaveService.js';
 import { RegistryService } from '../src/services/RegistryService.js';
-import { ProvisionService, extractAgentMetadata } from '../src/services/ProvisionService.js';
+import { ProvisionService } from '../src/services/ProvisionService.js';
 import { Artifact } from '../src/domain/entities/Artifact.js';
 import { Tenant } from '../src/domain/entities/Tenant.js';
 import { Deployment } from '../src/domain/entities/Deployment.js';

--- a/tests/registry-services.test.ts
+++ b/tests/registry-services.test.ts
@@ -4,10 +4,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { gzipSync } from 'node:zlib';
 import type { EntityManager } from '@mikro-orm/core';
 import { WeaveService } from '../src/services/WeaveService.js';
 import { RegistryService } from '../src/services/RegistryService.js';
-import { ProvisionService } from '../src/services/ProvisionService.js';
+import { ProvisionService, extractAgentMetadata } from '../src/services/ProvisionService.js';
 import { Artifact } from '../src/domain/entities/Artifact.js';
 import { Tenant } from '../src/domain/entities/Tenant.js';
 import { Deployment } from '../src/domain/entities/Deployment.js';
@@ -75,6 +76,35 @@ function makeArtifact(tenant: Tenant, overrides: Partial<Artifact> = {}): Artifa
     tags: [],
     ...overrides,
   });
+}
+
+/**
+ * Build a gzipped tar buffer from an array of files (for test bundles).
+ */
+function buildTestBundle(files: Array<{ path: string; data: Buffer }>): Buffer {
+  const blocks: Buffer[] = [];
+  for (const file of files) {
+    const header = Buffer.alloc(512);
+    header.write(file.path.slice(0, 99), 0, 'utf8');
+    header.write('0000644\0', 100, 'ascii');
+    header.write('0000000\0', 108, 'ascii');
+    header.write('0000000\0', 116, 'ascii');
+    header.write(file.data.length.toString(8).padStart(11, '0') + '\0', 124, 'ascii');
+    header.write(Math.floor(Date.now() / 1000).toString(8).padStart(11, '0') + '\0', 136, 'ascii');
+    header.fill(0x20, 148, 156);
+    header.write('0', 156, 'ascii');
+    header.write('ustar\0', 257, 'ascii');
+    header.write('00', 263, 'ascii');
+    let checksum = 0;
+    for (let i = 0; i < 512; i++) checksum += header[i]!;
+    header.write(checksum.toString(8).padStart(6, '0') + '\0 ', 148, 'ascii');
+    blocks.push(header);
+    const padded = Buffer.alloc(Math.ceil(file.data.length / 512) * 512);
+    file.data.copy(padded);
+    blocks.push(padded);
+  }
+  blocks.push(Buffer.alloc(1024));
+  return gzipSync(Buffer.concat(blocks));
 }
 
 // ── WeaveService ─────────────────────────────────────────────────────────────
@@ -388,6 +418,154 @@ describe('ProvisionService', () => {
 
       expect(result.status).toBe('FAILED');
       expect(result.errorMessage).toBe('Artifact not found');
+    });
+
+    it('extracts agent metadata from spec.json in bundle at deploy time', async () => {
+      const tenant = makeTenant({ id: tenantId });
+      const specJson = {
+        apiVersion: 'arachne-ai.com/v0',
+        kind: 'Agent',
+        metadata: { name: 'test-agent' },
+        spec: {
+          model: 'gpt-4.1-mini',
+          systemPrompt: 'You are a helpful assistant.',
+          knowledgeBaseRef: 'my-kb',
+          conversationsEnabled: true,
+          conversationTokenLimit: 8000,
+        },
+      };
+      const bundleData = buildTestBundle([
+        { path: 'manifest.json', data: Buffer.from(JSON.stringify({ kind: 'Agent', name: 'test-agent' })) },
+        { path: 'spec.json', data: Buffer.from(JSON.stringify(specJson)) },
+      ]);
+      const artifact = makeArtifact(tenant, { kind: 'Agent', bundleData, metadata: {} });
+
+      const mockRegistrySvc = {
+        resolve: vi.fn().mockResolvedValue(artifact),
+      } as unknown as RegistryService;
+      const svc = new ProvisionService(mockRegistrySvc);
+
+      const em = buildMockEm({
+        findOneOrFail: vi.fn().mockResolvedValue(tenant),
+      });
+
+      const result = await svc.deploy(
+        {
+          tenantId,
+          artifactRef: { org: 'myorg', name: 'test-agent', tag: 'latest' },
+          environment: 'production',
+          requestingUserId: 'user-1',
+        },
+        em,
+      );
+
+      expect(result.status).toBe('READY');
+      expect(artifact.metadata.systemPrompt).toBe('You are a helpful assistant.');
+      expect(artifact.metadata.model).toBe('gpt-4.1-mini');
+      expect(artifact.metadata.knowledgeBaseRef).toBe('my-kb');
+      expect(artifact.metadata.conversations_enabled).toBe(true);
+      expect(artifact.metadata.conversation_token_limit).toBe(8000);
+    });
+
+    it('extracts agent metadata from spec.yaml fallback', async () => {
+      const tenant = makeTenant({ id: tenantId });
+      const specYaml = `apiVersion: arachne-ai.com/v0
+kind: Agent
+metadata:
+  name: yaml-agent
+spec:
+  model: gpt-4.1-mini
+  systemPrompt: |
+    You are a YAML-based assistant.
+  knowledgeBaseRef: my-kb
+`;
+      const bundleData = buildTestBundle([
+        { path: 'manifest.json', data: Buffer.from(JSON.stringify({ kind: 'Agent', name: 'yaml-agent' })) },
+        { path: 'spec.yaml', data: Buffer.from(specYaml) },
+      ]);
+      const artifact = makeArtifact(tenant, { kind: 'Agent', bundleData, metadata: {} });
+
+      const mockRegistrySvc = {
+        resolve: vi.fn().mockResolvedValue(artifact),
+      } as unknown as RegistryService;
+      const svc = new ProvisionService(mockRegistrySvc);
+
+      const em = buildMockEm({
+        findOneOrFail: vi.fn().mockResolvedValue(tenant),
+      });
+
+      const result = await svc.deploy(
+        {
+          tenantId,
+          artifactRef: { org: 'myorg', name: 'yaml-agent', tag: 'latest' },
+          environment: 'production',
+          requestingUserId: 'user-1',
+        },
+        em,
+      );
+
+      expect(result.status).toBe('READY');
+      expect(artifact.metadata.systemPrompt).toBe('You are a YAML-based assistant.');
+      expect(artifact.metadata.model).toBe('gpt-4.1-mini');
+      expect(artifact.metadata.knowledgeBaseRef).toBe('my-kb');
+    });
+
+    it('skips metadata extraction for KnowledgeBase artifacts', async () => {
+      const tenant = makeTenant({ id: tenantId });
+      const artifact = makeArtifact(tenant, { kind: 'KnowledgeBase', metadata: {} });
+
+      const mockRegistrySvc = {
+        resolve: vi.fn().mockResolvedValue(artifact),
+      } as unknown as RegistryService;
+      const svc = new ProvisionService(mockRegistrySvc);
+
+      const em = buildMockEm({
+        findOneOrFail: vi.fn().mockResolvedValue(tenant),
+        count: vi.fn().mockResolvedValue(5),
+      });
+
+      await svc.deploy(
+        {
+          tenantId,
+          artifactRef: { org: 'myorg', name: 'my-kb', tag: 'latest' },
+          environment: 'production',
+          requestingUserId: 'user-1',
+        },
+        em,
+      );
+
+      expect(Object.keys(artifact.metadata)).toHaveLength(0);
+    });
+
+    it('deploy succeeds even if bundle extraction fails', async () => {
+      const tenant = makeTenant({ id: tenantId });
+      const artifact = makeArtifact(tenant, {
+        kind: 'Agent',
+        bundleData: Buffer.from('not-a-valid-gzip-bundle'),
+        metadata: {},
+      });
+
+      const mockRegistrySvc = {
+        resolve: vi.fn().mockResolvedValue(artifact),
+      } as unknown as RegistryService;
+      const svc = new ProvisionService(mockRegistrySvc);
+
+      const em = buildMockEm({
+        findOneOrFail: vi.fn().mockResolvedValue(tenant),
+      });
+
+      const result = await svc.deploy(
+        {
+          tenantId,
+          artifactRef: { org: 'myorg', name: 'bad-agent', tag: 'latest' },
+          environment: 'production',
+          requestingUserId: 'user-1',
+        },
+        em,
+      );
+
+      expect(result.status).toBe('READY');
+      expect(Object.keys(artifact.metadata)).toHaveLength(0);
     });
 
     it('returns FAILED when KnowledgeBase artifact has 0 chunks', async () => {


### PR DESCRIPTION
## Summary

Closes #154

- Deployed agents were missing their system prompt because `artifact.metadata` was never hydrated from the `.orb` bundle
- Added metadata extraction in `ProvisionService.deploy()` that reads `spec.json` (or `spec.yaml` fallback) from the bundle at deploy time
- Populates `systemPrompt`, `model`, `knowledgeBaseRef`, and conversation settings into `artifact.metadata`
- Extraction failures log a warning but do not block deployment (graceful degradation)

## Test plan

- [x] spec.json extraction (server-woven bundles)
- [x] spec.yaml fallback with block scalar parsing (CLI-woven bundles)
- [x] KnowledgeBase artifacts skip extraction
- [x] Corrupt bundles degrade gracefully (deployment still succeeds)
- [x] All 795 tests pass, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)