### PR TITLE
fix: use Docker-style random names for deployments (#157)

### DIFF
--- a/migrations/1000000000034_drop-deployment-artifact-env-unique.cjs
+++ b/migrations/1000000000034_drop-deployment-artifact-env-unique.cjs
@@ -1,0 +1,9 @@
+exports.up = (pgm) => {
+  pgm.dropConstraint('deployments', 'deployments_tenant_artifact_environment_unique');
+};
+
+exports.down = (pgm) => {
+  pgm.addConstraint('deployments', 'deployments_tenant_artifact_environment_unique', {
+    unique: ['tenant_id', 'artifact_id', 'environment'],
+  });
+};

--- a/src/domain/entities/Deployment.ts
+++ b/src/domain/entities/Deployment.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import type { Tenant } from './Tenant.js';
 import type { Artifact } from './Artifact.js';
+import { generateRandomName } from '../../utils/random-names.js';
 
 export type DeploymentStatus = 'PENDING' | 'READY' | 'FAILED';
 
@@ -32,7 +33,7 @@ export class Deployment {
     this.tenant = tenant;
     this.artifact = artifact;
     this.environment = environment;
-    this.name = name ?? `${(artifact as any).name}-${environment}`;
+    this.name = name ?? generateRandomName();
     this.status = 'PENDING';
     this.runtimeToken = null;
     this.errorMessage = null;

--- a/src/services/ProvisionService.ts
+++ b/src/services/ProvisionService.ts
@@ -68,33 +68,17 @@ export class ProvisionService {
       }
     }
 
-    // 3. Upsert: reuse existing deployment slot if one exists for this tenant + name
+    // 3. Create a new deployment (Docker-style: each deploy is a new slot)
     const tenant = await em.findOneOrFail(Tenant, { id: input.tenantId });
     const environment = input.environment ?? 'production';
-    const deploymentName = input.name ?? `${artifact.name}-${environment}`;
 
-    const existing = await em.findOne(Deployment, {
-      tenant: input.tenantId,
-      name: deploymentName,
-    });
-
-    let deployment: Deployment;
-    if (existing) {
-      existing.artifact = artifact;
-      existing.status = 'PENDING';
-      existing.errorMessage = null;
-      existing.environment = environment;
-      existing.updatedAt = new Date();
-      deployment = existing;
-    } else {
-      deployment = new Deployment(
-        tenant,
-        artifact,
-        environment,
-        input.name,
-      );
-      em.persist(deployment);
-    }
+    const deployment = new Deployment(
+      tenant,
+      artifact,
+      environment,
+      input.name,
+    );
+    em.persist(deployment);
     await em.flush();
 
     // 4. Validate KB readiness: KnowledgeBase artifacts must have chunks loaded

--- a/src/services/ProvisionService.ts
+++ b/src/services/ProvisionService.ts
@@ -68,15 +68,33 @@ export class ProvisionService {
       }
     }
 
-    // 3. Create Deployment entity with status PENDING
+    // 3. Upsert: reuse existing deployment slot if one exists for this tenant + name
     const tenant = await em.findOneOrFail(Tenant, { id: input.tenantId });
-    const deployment = new Deployment(
-      tenant,
-      artifact,
-      input.environment ?? 'production',
-      input.name,
-    );
-    em.persist(deployment);
+    const environment = input.environment ?? 'production';
+    const deploymentName = input.name ?? `${artifact.name}-${environment}`;
+
+    const existing = await em.findOne(Deployment, {
+      tenant: input.tenantId,
+      name: deploymentName,
+    });
+
+    let deployment: Deployment;
+    if (existing) {
+      existing.artifact = artifact;
+      existing.status = 'PENDING';
+      existing.errorMessage = null;
+      existing.environment = environment;
+      existing.updatedAt = new Date();
+      deployment = existing;
+    } else {
+      deployment = new Deployment(
+        tenant,
+        artifact,
+        environment,
+        input.name,
+      );
+      em.persist(deployment);
+    }
     await em.flush();
 
     // 4. Validate KB readiness: KnowledgeBase artifacts must have chunks loaded

--- a/src/utils/random-names.ts
+++ b/src/utils/random-names.ts
@@ -1,0 +1,17 @@
+const ADJECTIVES = ['brave', 'calm', 'eager', 'fair', 'gentle', 'happy', 'keen', 'lively', 'noble', 'proud',
+  'quick', 'sharp', 'swift', 'warm', 'wise', 'bold', 'bright', 'cool', 'daring', 'fierce',
+  'grand', 'honest', 'jolly', 'kind', 'lucky', 'merry', 'neat', 'patient', 'quiet', 'ready',
+  'solid', 'tough', 'vivid', 'witty', 'able', 'agile', 'clever', 'crisp', 'deep', 'electric',
+  'fresh', 'golden', 'humble', 'ivory', 'jade', 'keen', 'lunar', 'marble', 'olive', 'prime'];
+
+const NOUNS = ['falcon', 'river', 'thunder', 'crystal', 'summit', 'phoenix', 'glacier', 'aurora', 'ember', 'coral',
+  'cedar', 'meadow', 'harbor', 'prism', 'atlas', 'beacon', 'compass', 'delta', 'echo', 'forge',
+  'grove', 'haven', 'iris', 'jetty', 'kite', 'lantern', 'mesa', 'nexus', 'orbit', 'pebble',
+  'quartz', 'reef', 'sierra', 'tide', 'umbra', 'vale', 'wharf', 'zenith', 'arch', 'bloom',
+  'crest', 'drift', 'flint', 'gale', 'haze', 'inlet', 'knoll', 'loom', 'marsh', 'oasis'];
+
+export function generateRandomName(): string {
+  const adj = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
+  const noun = NOUNS[Math.floor(Math.random() * NOUNS.length)];
+  return `${adj}-${noun}`;
+}

--- a/tests/registry-services.test.ts
+++ b/tests/registry-services.test.ts
@@ -568,6 +568,47 @@ spec:
       expect(Object.keys(artifact.metadata)).toHaveLength(0);
     });
 
+    it('re-deploying same agent to same environment updates existing deployment (upsert)', async () => {
+      const tenant = makeTenant({ id: tenantId });
+      const artifact1 = makeArtifact(tenant, { id: 'artifact-v1', kind: 'Agent', name: 'my-agent' });
+      const artifact2 = makeArtifact(tenant, { id: 'artifact-v2', kind: 'Agent', name: 'my-agent' });
+
+      // Simulate existing deployment from first deploy
+      const existingDeployment = new Deployment(tenant, artifact1, 'production');
+      existingDeployment.markReady('old-token');
+      const originalId = existingDeployment.id;
+
+      const mockRegistrySvc = {
+        resolve: vi.fn().mockResolvedValue(artifact2),
+      } as unknown as RegistryService;
+      const svc = new ProvisionService(mockRegistrySvc);
+
+      // findOne returns the existing deployment (upsert lookup hit)
+      const em = buildMockEm({
+        findOne: vi.fn().mockResolvedValue(existingDeployment),
+        findOneOrFail: vi.fn().mockResolvedValue(tenant),
+      });
+
+      const result = await svc.deploy(
+        {
+          tenantId,
+          artifactRef: { org: 'myorg', name: 'my-agent', tag: 'latest' },
+          environment: 'production',
+          requestingUserId: 'user-1',
+        },
+        em,
+      );
+
+      expect(result.status).toBe('READY');
+      expect(result.deploymentId).toBe(originalId);
+      expect(result.runtimeToken).toBeTruthy();
+      expect(result.runtimeToken).not.toBe('old-token');
+      // Should NOT have called em.persist (reusing existing entity)
+      expect(em.persist).not.toHaveBeenCalled();
+      // The existing deployment's artifact should be updated to v2
+      expect(existingDeployment.artifact).toBe(artifact2);
+    });
+
     it('returns FAILED when KnowledgeBase artifact has 0 chunks', async () => {
       const tenant = makeTenant({ id: tenantId });
       const artifact = makeArtifact(tenant, { kind: 'KnowledgeBase' });

--- a/tests/registry-services.test.ts
+++ b/tests/registry-services.test.ts
@@ -568,24 +568,16 @@ spec:
       expect(Object.keys(artifact.metadata)).toHaveLength(0);
     });
 
-    it('re-deploying same agent to same environment updates existing deployment (upsert)', async () => {
+    it('generates a random name when no custom name provided', async () => {
       const tenant = makeTenant({ id: tenantId });
-      const artifact1 = makeArtifact(tenant, { id: 'artifact-v1', kind: 'Agent', name: 'my-agent' });
-      const artifact2 = makeArtifact(tenant, { id: 'artifact-v2', kind: 'Agent', name: 'my-agent' });
-
-      // Simulate existing deployment from first deploy
-      const existingDeployment = new Deployment(tenant, artifact1, 'production');
-      existingDeployment.markReady('old-token');
-      const originalId = existingDeployment.id;
+      const artifact = makeArtifact(tenant, { kind: 'Agent' });
 
       const mockRegistrySvc = {
-        resolve: vi.fn().mockResolvedValue(artifact2),
+        resolve: vi.fn().mockResolvedValue(artifact),
       } as unknown as RegistryService;
       const svc = new ProvisionService(mockRegistrySvc);
 
-      // findOne returns the existing deployment (upsert lookup hit)
       const em = buildMockEm({
-        findOne: vi.fn().mockResolvedValue(existingDeployment),
         findOneOrFail: vi.fn().mockResolvedValue(tenant),
       });
 
@@ -600,13 +592,82 @@ spec:
       );
 
       expect(result.status).toBe('READY');
-      expect(result.deploymentId).toBe(originalId);
-      expect(result.runtimeToken).toBeTruthy();
-      expect(result.runtimeToken).not.toBe('old-token');
-      // Should NOT have called em.persist (reusing existing entity)
-      expect(em.persist).not.toHaveBeenCalled();
-      // The existing deployment's artifact should be updated to v2
-      expect(existingDeployment.artifact).toBe(artifact2);
+      expect(result.name).toBeTruthy();
+      // Random name should be adjective-noun format
+      expect(result.name).toMatch(/^[a-z]+-[a-z]+$/);
+    });
+
+    it('uses custom name when provided via --name', async () => {
+      const tenant = makeTenant({ id: tenantId });
+      const artifact = makeArtifact(tenant, { kind: 'Agent' });
+
+      const mockRegistrySvc = {
+        resolve: vi.fn().mockResolvedValue(artifact),
+      } as unknown as RegistryService;
+      const svc = new ProvisionService(mockRegistrySvc);
+
+      const em = buildMockEm({
+        findOneOrFail: vi.fn().mockResolvedValue(tenant),
+      });
+
+      const result = await svc.deploy(
+        {
+          tenantId,
+          artifactRef: { org: 'myorg', name: 'my-agent', tag: 'latest' },
+          environment: 'production',
+          requestingUserId: 'user-1',
+          name: 'my-custom-deploy',
+        },
+        em,
+      );
+
+      expect(result.status).toBe('READY');
+      expect(result.name).toBe('my-custom-deploy');
+    });
+
+    it('two deploys of same artifact create two different deployments with different names', async () => {
+      const tenant = makeTenant({ id: tenantId });
+      const artifact = makeArtifact(tenant, { kind: 'Agent' });
+
+      const mockRegistrySvc = {
+        resolve: vi.fn().mockResolvedValue(artifact),
+      } as unknown as RegistryService;
+      const svc = new ProvisionService(mockRegistrySvc);
+
+      const em1 = buildMockEm({
+        findOneOrFail: vi.fn().mockResolvedValue(tenant),
+      });
+      const em2 = buildMockEm({
+        findOneOrFail: vi.fn().mockResolvedValue(tenant),
+      });
+
+      const result1 = await svc.deploy(
+        {
+          tenantId,
+          artifactRef: { org: 'myorg', name: 'my-agent', tag: 'latest' },
+          environment: 'production',
+          requestingUserId: 'user-1',
+        },
+        em1,
+      );
+
+      const result2 = await svc.deploy(
+        {
+          tenantId,
+          artifactRef: { org: 'myorg', name: 'my-agent', tag: 'latest' },
+          environment: 'production',
+          requestingUserId: 'user-1',
+        },
+        em2,
+      );
+
+      expect(result1.status).toBe('READY');
+      expect(result2.status).toBe('READY');
+      // Two separate deployments
+      expect(result1.deploymentId).not.toBe(result2.deploymentId);
+      // Both should have called em.persist (creating new entities each time)
+      expect(em1.persist).toHaveBeenCalled();
+      expect(em2.persist).toHaveBeenCalled();
     });
 
     it('returns FAILED when KnowledgeBase artifact has 0 chunks', async () => {


### PR DESCRIPTION
## Summary
- Replaced the deterministic deployment naming (`${artifactName}-${environment}`) with Docker-style random names (e.g., `brave-falcon`, `calm-river`)
- Each `arachne deploy` creates a NEW deployment with a unique random name (like Docker containers from the same image)
- Custom names still supported via `--name` flag
- Dropped the `(tenant_id, artifact_id, environment)` unique constraint so multiple deployments of the same agent are allowed
- Kept the `(tenant_id, name)` unique constraint (deployment names must be unique per tenant)

## Changes
- `src/utils/random-names.ts` (NEW): adjective-noun name generator (50x50 = 2500 combinations)
- `src/domain/entities/Deployment.ts`: uses `generateRandomName()` when no custom name provided
- `src/services/ProvisionService.ts`: always creates new deployment (no upsert)
- `migrations/1000000000034_drop-deployment-artifact-env-unique.cjs` (NEW): drops the artifact+environment constraint

## Test plan
- [x] Deploy generates random name when no `--name` provided
- [x] Deploy uses custom name when `--name` is provided
- [x] Two deploys of same artifact create two distinct deployments
- [x] `npm run build` passes (zero errors)
- [x] `npm test` passes (all green)

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)