### PR TITLE
fix: add token rotation endpoint for deployed agents (#158)

### DIFF
--- a/migrations/1000000000034_add-deployment-token-version.cjs
+++ b/migrations/1000000000034_add-deployment-token-version.cjs
@@ -1,0 +1,16 @@
+/**
+ * Add `token_version` column to deployments table.
+ * Used to invalidate old runtime tokens after rotation.
+ */
+
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+exports.up = (pgm) => {
+  pgm.addColumn('deployments', {
+    token_version: { type: 'integer', notNull: true, default: 1 },
+  });
+};
+
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+exports.down = (pgm) => {
+  pgm.dropColumn('deployments', 'token_version');
+};

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -153,6 +153,7 @@ export function registerAuthMiddleware(fastify: FastifyInstance): void {
           tenantId: string;
           artifactId: string;
           deploymentId: string;
+          tokenVersion?: number;
           scopes?: string[];
         }>(rawKey, RUNTIME_JWT_SECRET);
 
@@ -253,7 +254,7 @@ export async function invalidateAllKeysForTenant(tenantId: string, em: EntityMan
  * parent chain for provider resolution.
  */
 async function resolveRuntimeContext(
-  payload: { tenantId: string; artifactId: string; deploymentId: string },
+  payload: { tenantId: string; artifactId: string; deploymentId: string; tokenVersion?: number },
   em: EntityManager,
 ): Promise<TenantContext | null> {
   const deployment = await em.findOne(Deployment, {
@@ -262,6 +263,12 @@ async function resolveRuntimeContext(
   }, { populate: ['artifact'] });
 
   if (!deployment || deployment.status !== 'READY') return null;
+
+  // Reject tokens whose tokenVersion doesn't match (rotated tokens).
+  // Tokens minted before this change won't have tokenVersion, so allow them through.
+  if (payload.tokenVersion !== undefined && payload.tokenVersion !== deployment.tokenVersion) {
+    return null;
+  }
 
   const tenant = await em.findOne(Tenant, { id: payload.tenantId });
   if (!tenant || tenant.status !== 'active') return null;

--- a/src/domain/entities/Deployment.ts
+++ b/src/domain/entities/Deployment.ts
@@ -16,6 +16,7 @@ export class Deployment {
   environment!: string;
   name!: string;
   status!: DeploymentStatus;
+  tokenVersion!: number;
   runtimeToken!: string | null;
   errorMessage!: string | null;
   deployedAt!: Date | null;
@@ -34,6 +35,7 @@ export class Deployment {
     this.environment = environment;
     this.name = name ?? `${(artifact as any).name}-${environment}`;
     this.status = 'PENDING';
+    this.tokenVersion = 1;
     this.runtimeToken = null;
     this.errorMessage = null;
     this.deployedAt = null;

--- a/src/domain/schemas/Deployment.schema.ts
+++ b/src/domain/schemas/Deployment.schema.ts
@@ -13,6 +13,7 @@ export const DeploymentSchema = new EntitySchema<Deployment>({
     environment: { type: 'string', columnType: 'varchar(50)', default: 'production' },
     name: { type: 'string', columnType: 'varchar(200)' },
     status: { type: 'string', columnType: 'varchar(50)', default: 'PENDING' },
+    tokenVersion: { type: 'number', fieldName: 'token_version', default: 1 },
     runtimeToken: { type: 'text', fieldName: 'runtime_token', nullable: true },
     errorMessage: { type: 'text', fieldName: 'error_message', nullable: true },
     deployedAt: { type: 'Date', fieldName: 'deployed_at', nullable: true },

--- a/src/routes/registry.ts
+++ b/src/routes/registry.ts
@@ -196,6 +196,25 @@ export function registerRegistryRoutes(fastify: FastifyInstance): void {
     },
   );
 
+  // ── POST /v1/registry/deployments/:id/rotate-token ───────────────────────
+  fastify.post<{ Params: { id: string } }>(
+    '/v1/registry/deployments/:id/rotate-token',
+    { preHandler: registryAuth('deploy:write', REGISTRY_JWT_SECRET) },
+    async (request, reply) => {
+      const registryUser = (request as any).registryUser;
+      const { id } = request.params;
+      const em = request.em;
+
+      const result = await provisionService.rotateToken(id, registryUser.tenantId, em);
+
+      if (!result) {
+        return reply.code(404).send({ error: 'Deployment not found or not in READY state' });
+      }
+
+      return reply.send(result);
+    },
+  );
+
   // ── DELETE /v1/registry/deployments/:id ───────────────────────────────────
   fastify.delete<{ Params: { id: string } }>(
     '/v1/registry/deployments/:id',

--- a/src/services/ProvisionService.ts
+++ b/src/services/ProvisionService.ts
@@ -137,6 +137,40 @@ export class ProvisionService {
     return true;
   }
 
+  async rotateToken(
+    deploymentId: string,
+    tenantId: string,
+    em: EntityManager,
+  ): Promise<{ runtimeToken: string } | null> {
+    const deployment = await em.findOne(Deployment, {
+      id: deploymentId,
+      tenant: tenantId,
+    }, { populate: ['artifact'] });
+
+    if (!deployment || deployment.status !== 'READY') return null;
+
+    const artifactId = typeof deployment.artifact === 'string'
+      ? deployment.artifact
+      : deployment.artifact.id;
+
+    const runtimeToken = signJwt(
+      {
+        tenantId,
+        artifactId,
+        deploymentId: deployment.id,
+        scopes: [REGISTRY_SCOPES.RUNTIME_ACCESS],
+      },
+      RUNTIME_JWT_SECRET,
+      ONE_YEAR_MS,
+    );
+
+    deployment.runtimeToken = runtimeToken;
+    deployment.updatedAt = new Date();
+    await em.flush();
+
+    return { runtimeToken };
+  }
+
   async getDeployment(
     deploymentId: string,
     tenantId: string,

--- a/src/services/ProvisionService.ts
+++ b/src/services/ProvisionService.ts
@@ -100,6 +100,7 @@ export class ProvisionService {
         tenantId: input.tenantId,
         artifactId: artifact.id,
         deploymentId: deployment.id,
+        tokenVersion: deployment.tokenVersion,
         scopes: [REGISTRY_SCOPES.RUNTIME_ACCESS],
       },
       RUNTIME_JWT_SECRET,
@@ -153,11 +154,14 @@ export class ProvisionService {
       ? deployment.artifact
       : deployment.artifact.id;
 
+    deployment.tokenVersion += 1;
+
     const runtimeToken = signJwt(
       {
         tenantId,
         artifactId,
         deploymentId: deployment.id,
+        tokenVersion: deployment.tokenVersion,
         scopes: [REGISTRY_SCOPES.RUNTIME_ACCESS],
       },
       RUNTIME_JWT_SECRET,

--- a/tests/registry-routes.test.ts
+++ b/tests/registry-routes.test.ts
@@ -25,6 +25,7 @@ const { mockRegistryInstance, mockProvisionInstance } = vi.hoisted(() => {
     listDeployments: vi.fn(),
     unprovision: vi.fn(),
     findByName: vi.fn(),
+    rotateToken: vi.fn(),
   };
   return { mockRegistryInstance, mockProvisionInstance };
 });
@@ -758,6 +759,70 @@ describe('GET /v1/registry/deployments/by-name/:name', () => {
       url: '/v1/registry/deployments/by-name/some-name',
     });
     expect(res.statusCode).toBe(401);
+  });
+});
+
+// ── POST /v1/registry/deployments/:id/rotate-token ──────────────────────────
+
+describe('POST /v1/registry/deployments/:id/rotate-token', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildApp();
+  });
+
+  afterEach(async () => { await app.close(); });
+
+  it('returns 200 with new runtimeToken on success', async () => {
+    mockProvisionInstance.rotateToken.mockResolvedValue({
+      runtimeToken: 'new-rotated-token',
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/registry/deployments/deploy-001/rotate-token',
+      headers: { authorization: `Bearer ${deployToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const json = res.json();
+    expect(json.runtimeToken).toBe('new-rotated-token');
+    expect(mockProvisionInstance.rotateToken).toHaveBeenCalledWith(
+      'deploy-001',
+      TENANT_ID,
+      expect.anything(),
+    );
+  });
+
+  it('returns 404 when deployment is not found or not READY', async () => {
+    mockProvisionInstance.rotateToken.mockResolvedValue(null);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/registry/deployments/nonexistent/rotate-token',
+      headers: { authorization: `Bearer ${deployToken}` },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toMatch(/not found/i);
+  });
+
+  it('returns 401 when authorization header is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/registry/deployments/deploy-001/rotate-token',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 403 when token lacks deploy:write scope', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/registry/deployments/deploy-001/rotate-token',
+      headers: { authorization: `Bearer ${readToken}` },
+    });
+    expect(res.statusCode).toBe(403);
   });
 });
 

--- a/tests/registry-services.test.ts
+++ b/tests/registry-services.test.ts
@@ -626,6 +626,65 @@ spec:
     });
   });
 
+  describe('rotateToken', () => {
+    it('generates a new JWT, updates deployment, and returns it', async () => {
+      const svc = new ProvisionService({} as unknown as RegistryService);
+      const tenant = makeTenant({ id: tenantId });
+      const artifact = makeArtifact(tenant);
+      const deployment = new Deployment(tenant, artifact, 'production');
+      deployment.markReady('old-runtime-token');
+      const oldToken = deployment.runtimeToken;
+
+      const em = buildMockEm({
+        findOne: vi.fn().mockResolvedValue(deployment),
+      });
+
+      const result = await svc.rotateToken(deployment.id, tenantId, em);
+
+      expect(result).not.toBeNull();
+      expect(result!.runtimeToken).toBeTruthy();
+      expect(result!.runtimeToken).not.toBe(oldToken);
+      expect(deployment.runtimeToken).toBe(result!.runtimeToken);
+      expect(em.flush).toHaveBeenCalled();
+
+      // Verify the new token has the correct claims
+      const claims = verifyJwt<{
+        tenantId: string;
+        artifactId: string;
+        deploymentId: string;
+        scopes: string[];
+      }>(result!.runtimeToken, RUNTIME_JWT_SECRET);
+
+      expect(claims.tenantId).toBe(tenantId);
+      expect(claims.artifactId).toBe(artifact.id);
+      expect(claims.deploymentId).toBe(deployment.id);
+      expect(claims.scopes).toContain('runtime:access');
+    });
+
+    it('returns null when deployment is not found', async () => {
+      const svc = new ProvisionService({} as unknown as RegistryService);
+      const em = buildMockEm({ findOne: vi.fn().mockResolvedValue(null) });
+
+      const result = await svc.rotateToken('nonexistent-id', tenantId, em);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when deployment is not in READY state', async () => {
+      const svc = new ProvisionService({} as unknown as RegistryService);
+      const tenant = makeTenant({ id: tenantId });
+      const artifact = makeArtifact(tenant);
+      const deployment = new Deployment(tenant, artifact, 'production');
+      deployment.markFailed('some error');
+
+      const em = buildMockEm({
+        findOne: vi.fn().mockResolvedValue(deployment),
+      });
+
+      const result = await svc.rotateToken(deployment.id, tenantId, em);
+      expect(result).toBeNull();
+    });
+  });
+
   describe('unprovision', () => {
     it('marks deployment failed, clears runtime token, returns true', async () => {
       const svc = new ProvisionService({} as unknown as RegistryService);

--- a/tests/registry-services.test.ts
+++ b/tests/registry-services.test.ts
@@ -397,6 +397,7 @@ describe('ProvisionService', () => {
       expect(claims.artifactId).toBe(artifact.id);
       expect(claims.deploymentId).toBe(result.deploymentId);
       expect(claims.scopes).toContain('runtime:access');
+      expect(claims.tokenVersion).toBe(1);
     });
 
     it('returns FAILED (no deployment row) when artifact not found', async () => {
@@ -652,6 +653,7 @@ spec:
         tenantId: string;
         artifactId: string;
         deploymentId: string;
+        tokenVersion: number;
         scopes: string[];
       }>(result!.runtimeToken, RUNTIME_JWT_SECRET);
 
@@ -659,6 +661,36 @@ spec:
       expect(claims.artifactId).toBe(artifact.id);
       expect(claims.deploymentId).toBe(deployment.id);
       expect(claims.scopes).toContain('runtime:access');
+      expect(claims.tokenVersion).toBe(2);
+    });
+
+    it('increments tokenVersion so the old token version no longer matches', async () => {
+      const svc = new ProvisionService({} as unknown as RegistryService);
+      const tenant = makeTenant({ id: tenantId });
+      const artifact = makeArtifact(tenant);
+      const deployment = new Deployment(tenant, artifact, 'production');
+      deployment.markReady('old-runtime-token');
+
+      expect(deployment.tokenVersion).toBe(1);
+
+      const em = buildMockEm({
+        findOne: vi.fn().mockResolvedValue(deployment),
+      });
+
+      const result = await svc.rotateToken(deployment.id, tenantId, em);
+
+      // tokenVersion on the deployment entity should be incremented
+      expect(deployment.tokenVersion).toBe(2);
+
+      // The new token should carry tokenVersion=2
+      const newClaims = verifyJwt<{ tokenVersion: number }>(
+        result!.runtimeToken,
+        RUNTIME_JWT_SECRET,
+      );
+      expect(newClaims.tokenVersion).toBe(2);
+
+      // An old token with tokenVersion=1 would not match deployment.tokenVersion (2)
+      // This is validated at auth time in resolveRuntimeContext
     });
 
     it('returns null when deployment is not found', async () => {

--- a/tests/runtime-auth.test.ts
+++ b/tests/runtime-auth.test.ts
@@ -39,6 +39,11 @@ function mintRuntimeToken(
   );
 }
 
+// Simulated deployment store for tokenVersion validation
+const DEPLOYMENT_TOKEN_VERSIONS: Record<string, number> = {
+  [TEST_DEPLOYMENT_ID]: 1,
+};
+
 // Build a test gateway that mirrors the real auth middleware's runtime JWT path
 function buildRuntimeAuthGateway(port: number): FastifyInstance {
   const app = Fastify({ logger: false });
@@ -71,6 +76,7 @@ function buildRuntimeAuthGateway(port: number): FastifyInstance {
           tenantId: string;
           artifactId: string;
           deploymentId: string;
+          tokenVersion?: number;
           scopes?: string[];
         };
 
@@ -84,14 +90,24 @@ function buildRuntimeAuthGateway(port: number): FastifyInstance {
           });
         }
 
-        // Simulate successful runtime context resolution
-        (request as any).tenant = {
-          tenantId: payload.tenantId,
-          name: 'Runtime Tenant',
-          agentId: payload.deploymentId,
-          mergePolicies: { system_prompt: 'prepend', skills: 'merge' },
-        };
-        return;
+        // Validate tokenVersion (mirrors resolveRuntimeContext in src/auth.ts)
+        const currentVersion = DEPLOYMENT_TOKEN_VERSIONS[payload.deploymentId];
+        if (
+          payload.tokenVersion !== undefined &&
+          currentVersion !== undefined &&
+          payload.tokenVersion !== currentVersion
+        ) {
+          // Token has been rotated; fall through to API key path (will 401)
+        } else {
+          // Simulate successful runtime context resolution
+          (request as any).tenant = {
+            tenantId: payload.tenantId,
+            name: 'Runtime Tenant',
+            agentId: payload.deploymentId,
+            mergePolicies: { system_prompt: 'prepend', skills: 'merge' },
+          };
+          return;
+        }
       } catch {
         // JWT verification failed, fall through to API key path
       }
@@ -339,5 +355,96 @@ describe('runtime-auth: API key auth regression', () => {
     });
 
     expect(res.status).toBe(401);
+  });
+});
+
+describe('runtime-auth: tokenVersion invalidation', () => {
+  let app: FastifyInstance;
+  const PORT = 3044;
+
+  beforeAll(async () => {
+    // Reset deployment token version to 1 for this test suite
+    DEPLOYMENT_TOKEN_VERSIONS[TEST_DEPLOYMENT_ID] = 1;
+    app = buildRuntimeAuthGateway(PORT);
+    await app.listen({ port: PORT, host: '127.0.0.1' });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('token with matching tokenVersion is accepted', async () => {
+    const token = mintRuntimeToken({ tokenVersion: 1 });
+
+    const res = await fetch(`http://127.0.0.1:${PORT}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ model: 'gpt-4', messages: [] }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('token with old tokenVersion is rejected after rotation', async () => {
+    // Simulate rotation: deployment now at version 2
+    DEPLOYMENT_TOKEN_VERSIONS[TEST_DEPLOYMENT_ID] = 2;
+
+    const oldToken = mintRuntimeToken({ tokenVersion: 1 });
+
+    const res = await fetch(`http://127.0.0.1:${PORT}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${oldToken}`,
+      },
+      body: JSON.stringify({ model: 'gpt-4', messages: [] }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('token with new tokenVersion is accepted after rotation', async () => {
+    // deployment is at version 2 from previous test
+    const newToken = mintRuntimeToken({ tokenVersion: 2 });
+
+    const res = await fetch(`http://127.0.0.1:${PORT}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${newToken}`,
+      },
+      body: JSON.stringify({ model: 'gpt-4', messages: [] }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('token without tokenVersion is allowed through (backward compatibility)', async () => {
+    // Tokens minted before this change won't have tokenVersion
+    const legacyToken = jwt.sign(
+      {
+        tenantId: TEST_TENANT_ID,
+        artifactId: TEST_ARTIFACT_ID,
+        deploymentId: TEST_DEPLOYMENT_ID,
+        scopes: ['runtime:access'],
+        // no tokenVersion field
+      },
+      TEST_SECRET,
+      { expiresIn: '1h' },
+    );
+
+    const res = await fetch(`http://127.0.0.1:${PORT}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${legacyToken}`,
+      },
+      body: JSON.stringify({ model: 'gpt-4', messages: [] }),
+    });
+
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary
- Added `POST /v1/registry/deployments/:id/rotate-token` endpoint
- Requires `deploy:write` scope (same auth as deploy/unprovision)
- Creates a new runtime JWT, updates the deployment record, returns the new token
- Added `rotateToken()` method to `ProvisionService` for the business logic
- Old token is replaced (no longer stored on the deployment)

## Test plan
- [x] Route tests: happy path, 404, 401, 403
- [x] Service tests: JWT claim verification, not found, not READY state
- [x] `npm run build` passes (zero errors)
- [x] `npm test` passes (all registry tests green)

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)