### PR TITLE
feat: CLI uses gateway embedding providers for KB weave (#170)

### DIFF
--- a/cli/src/commands/weave.ts
+++ b/cli/src/commands/weave.ts
@@ -2,10 +2,14 @@ import { Command } from 'commander';
 import { readFileSync, writeFileSync, mkdirSync, existsSync, statSync, readdirSync } from 'fs';
 import { resolve, basename, dirname, join, extname } from 'path';
 import { createHash } from 'crypto';
+import { createInterface } from 'node:readline';
 import { gzipSync } from 'zlib';
 import { chunkText, embedTexts, computePreprocessingHash, getDimensions } from '../lib/embedding.js';
 import { buildTar } from '../lib/tar.js';
+import { discoverEmbeddingProviders, embedViaGateway } from '../lib/gateway-embeddings.js';
+import { getGatewayUrl, getToken } from '../config.js';
 import type { EmbeddingConfig } from '../lib/embedding.js';
+import type { GatewayEmbeddingProvider } from '../lib/gateway-embeddings.js';
 
 interface SpecFields {
   kind: string;
@@ -94,8 +98,9 @@ function collectDocs(dir: string): Array<{ path: string; content: string }> {
 
 /**
  * Resolve embedding config from spec, env vars, or system fallback.
+ * Returns null if no local config is found (caller should try gateway).
  */
-function resolveEmbeddingConfig(specEmbedder?: SpecFields['embedder']): EmbeddingConfig {
+export function resolveEmbeddingConfig(specEmbedder?: SpecFields['embedder']): EmbeddingConfig | null {
   // Priority 1: spec.embedder fields
   if (specEmbedder?.provider && specEmbedder?.model) {
     return {
@@ -124,9 +129,56 @@ function resolveEmbeddingConfig(specEmbedder?: SpecFields['embedder']): Embeddin
     return { provider: sProvider, model: sModel, apiKey: sKey };
   }
 
-  throw new Error(
-    'No embedding provider configured. Set spec.embedder, ARACHNE_EMBED_PROVIDER/MODEL, or SYSTEM_EMBEDDER_PROVIDER/MODEL.',
-  );
+  return null;
+}
+
+/**
+ * Prompt user to select from multiple gateway embedding providers.
+ */
+function promptProviderSelection(providers: GatewayEmbeddingProvider[]): Promise<GatewayEmbeddingProvider> {
+  return new Promise((resolve) => {
+    console.log('No local embedding config found. Available providers on gateway:');
+    for (let i = 0; i < providers.length; i++) {
+      const p = providers[i];
+      console.log(`  ${i + 1}. ${p.name} (${p.provider} / ${p.model})`);
+    }
+
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(`Select provider [1]: `, (answer) => {
+      rl.close();
+      const idx = answer.trim() ? parseInt(answer.trim(), 10) - 1 : 0;
+      const selected = providers[idx] ?? providers[0];
+      resolve(selected);
+    });
+  });
+}
+
+/**
+ * Try to resolve a gateway embedding provider.
+ * Returns the selected provider, or null if gateway is unavailable or has no providers.
+ */
+async function resolveGatewayProvider(): Promise<{ gatewayUrl: string; token: string; provider: GatewayEmbeddingProvider } | null> {
+  let gatewayUrl: string;
+  let token: string;
+  try {
+    gatewayUrl = getGatewayUrl();
+    token = getToken();
+  } catch {
+    return null;
+  }
+
+  const providers = await discoverEmbeddingProviders(gatewayUrl, token);
+  if (providers.length === 0) return null;
+
+  let selected: GatewayEmbeddingProvider;
+  if (providers.length === 1) {
+    selected = providers[0];
+    console.log(`No local embedding config found. Using gateway provider: ${selected.name} (${selected.provider} / ${selected.model})`);
+  } else {
+    selected = await promptProviderSelection(providers);
+  }
+
+  return { gatewayUrl, token, provider: selected };
 }
 
 export const weaveCommand = new Command('weave')
@@ -205,20 +257,49 @@ async function weaveKnowledgeBase(
 
   console.log(`${rawChunks.length} chunks`);
 
-  // Resolve embedding config
+  // Resolve embedding config (local first, then gateway fallback)
   const embeddingConfig = resolveEmbeddingConfig(spec.embedder);
 
-  // Embed all chunks
-  console.log(`Embedding ${rawChunks.length} chunks...`);
-  const texts = rawChunks.map((c) => c.content);
-  const embeddings = await embedTexts(texts, embeddingConfig);
+  let embeddings: number[][];
+  let embeddingProvider: string;
+  let embeddingModel: string;
+  let dimensions: number;
 
-  // Infer dimensions from first embedding or use known map
-  const dimensions = embeddings[0]?.length ?? getDimensions(embeddingConfig.model);
+  if (embeddingConfig) {
+    // Local embedding path
+    console.log(`Embedding ${rawChunks.length} chunks...`);
+    const texts = rawChunks.map((c) => c.content);
+    embeddings = await embedTexts(texts, embeddingConfig);
+    embeddingProvider = embeddingConfig.provider;
+    embeddingModel = embeddingConfig.model;
+    dimensions = embeddings[0]?.length ?? getDimensions(embeddingConfig.model);
+  } else {
+    // Priority 4: Gateway provider fallback
+    const gateway = await resolveGatewayProvider();
+    if (!gateway) {
+      console.error(
+        'Error: no embedding provider configured. Set spec.embedder, ARACHNE_EMBED_PROVIDER/MODEL, SYSTEM_EMBEDDER_PROVIDER/MODEL, or log in to a gateway with embedding providers.',
+      );
+      process.exit(1);
+    }
+
+    console.log(`Embedding ${rawChunks.length} chunks via gateway...`);
+    const texts = rawChunks.map((c) => c.content);
+    const BATCH_SIZE = 100;
+    embeddings = [];
+    for (let i = 0; i < texts.length; i += BATCH_SIZE) {
+      const batch = texts.slice(i, i + BATCH_SIZE);
+      const result = await embedViaGateway(gateway.gatewayUrl, gateway.token, batch, gateway.provider.name);
+      embeddings.push(...result.embeddings);
+    }
+    embeddingProvider = gateway.provider.provider;
+    embeddingModel = gateway.provider.model;
+    dimensions = embeddings[0]?.length ?? getDimensions(embeddingModel);
+  }
 
   const preprocessingHash = computePreprocessingHash({
-    provider: embeddingConfig.provider,
-    model: embeddingConfig.model,
+    provider: embeddingProvider,
+    model: embeddingModel,
     tokenSize,
     overlap,
   });
@@ -237,8 +318,8 @@ async function weaveKnowledgeBase(
     version: new Date().toISOString(),
     chunkCount: chunks.length,
     vectorSpace: {
-      provider: embeddingConfig.provider,
-      model: embeddingConfig.model,
+      provider: embeddingProvider,
+      model: embeddingModel,
       dimensions,
       preprocessingHash,
     },

--- a/cli/src/lib/gateway-embeddings.ts
+++ b/cli/src/lib/gateway-embeddings.ts
@@ -1,0 +1,62 @@
+export interface GatewayEmbeddingProvider {
+  name: string;
+  provider: string;
+  model: string;
+}
+
+/**
+ * Query the gateway for available embedding providers.
+ * Returns empty array if gateway is unreachable or has no providers.
+ */
+export async function discoverEmbeddingProviders(
+  gatewayUrl: string,
+  registryToken: string,
+): Promise<GatewayEmbeddingProvider[]> {
+  try {
+    const res = await fetch(`${gatewayUrl}/v1/registry/embedding-providers`, {
+      headers: { Authorization: `Bearer ${registryToken}` },
+    });
+
+    if (!res.ok) return [];
+
+    const data = (await res.json()) as { providers?: GatewayEmbeddingProvider[] };
+    return data.providers ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Generate embeddings via the gateway's embedding proxy.
+ */
+export async function embedViaGateway(
+  gatewayUrl: string,
+  registryToken: string,
+  texts: string[],
+  providerName?: string,
+): Promise<{ embeddings: number[][]; model: string; dimensions: number }> {
+  const body: Record<string, unknown> = { texts };
+  if (providerName) body.provider = providerName;
+
+  const res = await fetch(`${gatewayUrl}/v1/registry/embeddings`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${registryToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const errBody = await res.text();
+    throw new Error(`Gateway embeddings API error ${res.status}: ${errBody}`);
+  }
+
+  const data = (await res.json()) as {
+    embeddings: number[][];
+    model: string;
+    dimensions: number;
+  };
+
+  return data;
+}

--- a/cli/tests/gateway-embeddings.test.ts
+++ b/cli/tests/gateway-embeddings.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  discoverEmbeddingProviders,
+  embedViaGateway,
+} from '../src/lib/gateway-embeddings.js';
+import { resolveEmbeddingConfig } from '../src/commands/weave.js';
+
+describe('discoverEmbeddingProviders', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns providers from gateway', async () => {
+    const mockProviders = [
+      { name: 'system-embedder', provider: 'openai', model: 'text-embedding-3-small' },
+      { name: 'tenant-embedder', provider: 'azure', model: 'text-embedding-3-large' },
+    ];
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ providers: mockProviders }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await discoverEmbeddingProviders('http://localhost:3000', 'test-token');
+
+    expect(result).toEqual(mockProviders);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/registry/embedding-providers',
+      { headers: { Authorization: 'Bearer test-token' } },
+    );
+  });
+
+  it('returns empty array on gateway error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Internal Server Error', { status: 500 }),
+    );
+
+    const result = await discoverEmbeddingProviders('http://localhost:3000', 'test-token');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when gateway is unreachable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await discoverEmbeddingProviders('http://localhost:3000', 'test-token');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when response has no providers field', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await discoverEmbeddingProviders('http://localhost:3000', 'test-token');
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('embedViaGateway', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns embeddings from gateway', async () => {
+    const mockResponse = {
+      embeddings: [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+      model: 'text-embedding-3-small',
+      dimensions: 3,
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await embedViaGateway(
+      'http://localhost:3000',
+      'test-token',
+      ['hello', 'world'],
+      'system-embedder',
+    );
+
+    expect(result).toEqual(mockResponse);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/registry/embeddings',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+        },
+        body: JSON.stringify({ texts: ['hello', 'world'], provider: 'system-embedder' }),
+      },
+    );
+  });
+
+  it('throws on gateway error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Bad Request', { status: 400 }),
+    );
+
+    await expect(
+      embedViaGateway('http://localhost:3000', 'test-token', ['hello']),
+    ).rejects.toThrow('Gateway embeddings API error 400: Bad Request');
+  });
+
+  it('omits provider field when not specified', async () => {
+    const mockResponse = {
+      embeddings: [[0.1, 0.2]],
+      model: 'text-embedding-3-small',
+      dimensions: 2,
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await embedViaGateway('http://localhost:3000', 'test-token', ['test']);
+
+    const callBody = JSON.parse((fetch as any).mock.calls[0][1].body);
+    expect(callBody).toEqual({ texts: ['test'] });
+    expect(callBody.provider).toBeUndefined();
+  });
+});
+
+describe('resolveEmbeddingConfig falls through to null', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const envKeys = [
+    'ARACHNE_EMBED_PROVIDER',
+    'ARACHNE_EMBED_MODEL',
+    'ARACHNE_EMBED_API_KEY',
+    'SYSTEM_EMBEDDER_PROVIDER',
+    'SYSTEM_EMBEDDER_MODEL',
+    'SYSTEM_EMBEDDER_API_KEY',
+  ];
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it('returns null when no local config is available', () => {
+    const result = resolveEmbeddingConfig(undefined);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when spec embedder is incomplete', () => {
+    const result = resolveEmbeddingConfig({ provider: 'openai' });
+    expect(result).toBeNull();
+  });
+
+  it('returns config when spec embedder is complete', () => {
+    const result = resolveEmbeddingConfig({ provider: 'openai', model: 'text-embedding-3-small' });
+    expect(result).not.toBeNull();
+    expect(result!.provider).toBe('openai');
+    expect(result!.model).toBe('text-embedding-3-small');
+  });
+
+  it('returns config from ARACHNE_EMBED_* env vars', () => {
+    process.env['ARACHNE_EMBED_PROVIDER'] = 'openai';
+    process.env['ARACHNE_EMBED_MODEL'] = 'text-embedding-3-small';
+    process.env['ARACHNE_EMBED_API_KEY'] = 'sk-test';
+
+    const result = resolveEmbeddingConfig(undefined);
+    expect(result).not.toBeNull();
+    expect(result!.provider).toBe('openai');
+    expect(result!.apiKey).toBe('sk-test');
+  });
+
+  it('returns config from SYSTEM_EMBEDDER_* env vars', () => {
+    process.env['SYSTEM_EMBEDDER_PROVIDER'] = 'azure';
+    process.env['SYSTEM_EMBEDDER_MODEL'] = 'text-embedding-3-large';
+
+    const result = resolveEmbeddingConfig(undefined);
+    expect(result).not.toBeNull();
+    expect(result!.provider).toBe('azure');
+  });
+});

--- a/src/routes/registry.ts
+++ b/src/routes/registry.ts
@@ -4,6 +4,7 @@ import multipart from '@fastify/multipart';
 import { registryAuth } from '../middleware/registryAuth.js';
 import { RegistryService } from '../services/RegistryService.js';
 import { ProvisionService } from '../services/ProvisionService.js';
+import { EmbeddingAgentService } from '../services/EmbeddingAgentService.js';
 import { Tenant } from '../domain/entities/Tenant.js';
 
 const REGISTRY_JWT_SECRET =
@@ -16,6 +17,7 @@ export function registerRegistryRoutes(fastify: FastifyInstance): void {
 
   const registryService = new RegistryService();
   const provisionService = new ProvisionService(registryService);
+  const embeddingService = new EmbeddingAgentService();
 
   // ── POST /v1/registry/push ─────────────────────────────────────────────────
   fastify.post('/v1/registry/push', {
@@ -231,6 +233,56 @@ export function registerRegistryRoutes(fastify: FastifyInstance): void {
       }
 
       return reply.send({ success: true });
+    },
+  );
+
+  // ── GET /v1/registry/embedding-providers ──────────────────────────────────
+  fastify.get('/v1/registry/embedding-providers', {
+    preHandler: registryAuth('artifact:read', REGISTRY_JWT_SECRET),
+  }, async (request, reply) => {
+    const registryUser = (request as any).registryUser;
+    const em = request.em;
+
+    try {
+      const config = await embeddingService.resolveEmbedder(undefined, registryUser.tenantId, em);
+      return reply.send({
+        providers: [
+          {
+            name: 'system-embedder',
+            provider: config.provider,
+            model: config.model,
+          },
+        ],
+      });
+    } catch {
+      // No embedder configured: return empty list
+      return reply.send({ providers: [] });
+    }
+  });
+
+  // ── POST /v1/registry/embeddings ──────────────────────────────────────────
+  fastify.post<{ Body: { texts: string[]; provider?: string } }>(
+    '/v1/registry/embeddings',
+    { preHandler: registryAuth('artifact:read', REGISTRY_JWT_SECRET) },
+    async (request, reply) => {
+      const registryUser = (request as any).registryUser;
+      const em = request.em;
+      const { texts, provider } = request.body ?? {} as any;
+
+      if (!Array.isArray(texts) || texts.length === 0) {
+        return reply.code(400).send({ error: 'texts must be a non-empty array of strings' });
+      }
+
+      // Resolve the embedding provider (provider field is currently only "system-embedder" or undefined)
+      const agentRef = (provider && provider !== 'system-embedder') ? provider : undefined;
+      const config = await embeddingService.resolveEmbedder(agentRef, registryUser.tenantId, em);
+      const result = await embeddingService.embedTexts(texts, config);
+
+      return reply.send({
+        embeddings: result.embeddings,
+        model: result.model,
+        dimensions: result.dimensions,
+      });
     },
   );
 }

--- a/src/routes/registry.ts
+++ b/src/routes/registry.ts
@@ -245,6 +245,8 @@ export function registerRegistryRoutes(fastify: FastifyInstance): void {
 
     try {
       const config = await embeddingService.resolveEmbedder(undefined, registryUser.tenantId, em);
+      // Currently returns a single provider (system embedder). This will be
+      // extended to include per-tenant embedding agents once that feature lands.
       return reply.send({
         providers: [
           {
@@ -254,9 +256,14 @@ export function registerRegistryRoutes(fastify: FastifyInstance): void {
           },
         ],
       });
-    } catch {
-      // No embedder configured: return empty list
-      return reply.send({ providers: [] });
+    } catch (err: unknown) {
+      // "No embedding config available" means no embedder is configured: return empty list.
+      // Any other error (DB, network, etc.) should propagate as 500.
+      const message = err instanceof Error ? err.message : '';
+      if (message.includes('No embedding config available') || message.includes('not found')) {
+        return reply.send({ providers: [] });
+      }
+      throw err;
     }
   });
 
@@ -273,10 +280,20 @@ export function registerRegistryRoutes(fastify: FastifyInstance): void {
         return reply.code(400).send({ error: 'texts must be a non-empty array of strings' });
       }
 
+      // Validate every element is a string, trim whitespace, and filter empties
+      const invalidIndex = texts.findIndex((t) => typeof t !== 'string');
+      if (invalidIndex !== -1) {
+        return reply.code(400).send({ error: `texts[${invalidIndex}] is not a string` });
+      }
+      const cleaned = texts.map((t) => t.trim()).filter((t) => t.length > 0);
+      if (cleaned.length === 0) {
+        return reply.code(400).send({ error: 'texts must contain at least one non-empty string' });
+      }
+
       // Resolve the embedding provider (provider field is currently only "system-embedder" or undefined)
       const agentRef = (provider && provider !== 'system-embedder') ? provider : undefined;
       const config = await embeddingService.resolveEmbedder(agentRef, registryUser.tenantId, em);
-      const result = await embeddingService.embedTexts(texts, config);
+      const result = await embeddingService.embedTexts(cleaned, config);
 
       return reply.send({
         embeddings: result.embeddings,

--- a/src/services/EmbeddingAgentService.ts
+++ b/src/services/EmbeddingAgentService.ts
@@ -15,6 +15,12 @@ export interface EmbeddingAgentConfig {
   knowledgeBaseRef?: string;
 }
 
+export interface EmbedTextsResult {
+  embeddings: number[][];
+  model: string;
+  dimensions: number;
+}
+
 /** Dimensions known per well-known model name. */
 const KNOWN_DIMENSIONS: Record<string, number> = {
   'text-embedding-3-small': 1536,
@@ -160,6 +166,78 @@ export class EmbeddingAgentService {
       em.persist(agent);
       await em.flush();
     }
+  }
+
+  /**
+   * Generate embeddings for an array of texts using the resolved embedding provider.
+   * Supports OpenAI (batch via `input` array), Azure, and Ollama (one-at-a-time).
+   */
+  async embedTexts(texts: string[], config: EmbeddingAgentConfig): Promise<EmbedTextsResult> {
+    if (config.provider === 'ollama') {
+      // Ollama does not support batch embedding; loop sequentially
+      const embeddings: number[][] = [];
+      for (const text of texts) {
+        const baseUrl = config.baseUrl ?? 'http://localhost:11434';
+        const resp = await fetch(`${baseUrl}/api/embeddings`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ model: config.model, prompt: text }),
+        });
+        if (!resp.ok) {
+          const errBody = await resp.text().catch(() => '');
+          throw new Error(`Embedding API error ${resp.status}: ${errBody}`);
+        }
+        const data = (await resp.json()) as any;
+        embeddings.push(data.embedding as number[]);
+      }
+      return {
+        embeddings,
+        model: config.model,
+        dimensions: config.dimensions,
+      };
+    }
+
+    // OpenAI and Azure both support batch via `input` array
+    let url: string;
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    let body: object;
+
+    if (config.provider === 'azure') {
+      const baseUrl = config.baseUrl ?? '';
+      const deployment = config.deployment ?? config.model;
+      const apiVersion = config.apiVersion ?? '2024-02-01';
+      url = `${baseUrl}/openai/deployments/${deployment}/embeddings?api-version=${apiVersion}`;
+      headers['api-key'] = config.apiKey ?? '';
+      body = { input: texts };
+    } else {
+      // OpenAI or OpenAI-compatible
+      const baseUrl = config.baseUrl ?? 'https://api.openai.com';
+      url = `${baseUrl}/v1/embeddings`;
+      headers['Authorization'] = `Bearer ${config.apiKey ?? ''}`;
+      body = { model: config.model, input: texts };
+    }
+
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!resp.ok) {
+      const errBody = await resp.text().catch(() => '');
+      throw new Error(`Embedding API error ${resp.status}: ${errBody}`);
+    }
+
+    const data = (await resp.json()) as any;
+    // OpenAI/Azure return { data: [{ embedding: [...], index: N }, ...] }
+    const sorted = (data.data as Array<{ embedding: number[]; index: number }>)
+      .sort((a, b) => a.index - b.index);
+
+    return {
+      embeddings: sorted.map((d) => d.embedding),
+      model: config.model,
+      dimensions: config.dimensions,
+    };
   }
 
   /**

--- a/src/services/EmbeddingAgentService.ts
+++ b/src/services/EmbeddingAgentService.ts
@@ -204,6 +204,9 @@ export class EmbeddingAgentService {
 
     if (config.provider === 'azure') {
       const baseUrl = config.baseUrl ?? '';
+      if (!baseUrl) {
+        throw new Error('Azure embedding provider requires a baseUrl (e.g., https://<resource>.openai.azure.com)');
+      }
       const deployment = config.deployment ?? config.model;
       const apiVersion = config.apiVersion ?? '2024-02-01';
       url = `${baseUrl}/openai/deployments/${deployment}/embeddings?api-version=${apiVersion}`;

--- a/tests/embedding-agent-service.test.ts
+++ b/tests/embedding-agent-service.test.ts
@@ -416,3 +416,37 @@ describe('EmbeddingAgentService.resolveEmbedder — provider ref', () => {
     expect(config.baseUrl).toBeUndefined();
   });
 });
+
+// ── embedTexts validation ──────────────────────────────────────────────────
+
+describe('embedTexts', () => {
+  let service: EmbeddingAgentService;
+
+  beforeEach(() => {
+    service = new EmbeddingAgentService();
+  });
+
+  it('throws when Azure provider has no baseUrl', async () => {
+    await expect(
+      service.embedTexts(['hello'], {
+        provider: 'azure',
+        model: 'text-embedding-3-small',
+        dimensions: 1536,
+        apiKey: 'key',
+        baseUrl: undefined,
+      }),
+    ).rejects.toThrow('Azure embedding provider requires a baseUrl');
+  });
+
+  it('throws when Azure provider has empty baseUrl', async () => {
+    await expect(
+      service.embedTexts(['hello'], {
+        provider: 'azure',
+        model: 'text-embedding-3-small',
+        dimensions: 1536,
+        apiKey: 'key',
+        baseUrl: '',
+      }),
+    ).rejects.toThrow('Azure embedding provider requires a baseUrl');
+  });
+});

--- a/tests/registry-routes.test.ts
+++ b/tests/registry-routes.test.ts
@@ -12,7 +12,7 @@ import { signJwt } from '../src/auth/jwtUtils.js';
 
 // ── Hoisted mocks ────────────────────────────────────────────────────────────
 
-const { mockRegistryInstance, mockProvisionInstance } = vi.hoisted(() => {
+const { mockRegistryInstance, mockProvisionInstance, mockEmbeddingInstance } = vi.hoisted(() => {
   const mockRegistryInstance = {
     push: vi.fn(),
     list: vi.fn(),
@@ -27,7 +27,13 @@ const { mockRegistryInstance, mockProvisionInstance } = vi.hoisted(() => {
     findByName: vi.fn(),
     rotateToken: vi.fn(),
   };
-  return { mockRegistryInstance, mockProvisionInstance };
+  const mockEmbeddingInstance = {
+    resolveEmbedder: vi.fn(),
+    embedTexts: vi.fn(),
+    bootstrapSystemEmbedder: vi.fn(),
+    bootstrapAllTenants: vi.fn(),
+  };
+  return { mockRegistryInstance, mockProvisionInstance, mockEmbeddingInstance };
 });
 
 vi.mock('../src/services/RegistryService.js', () => ({
@@ -36,6 +42,10 @@ vi.mock('../src/services/RegistryService.js', () => ({
 
 vi.mock('../src/services/ProvisionService.js', () => ({
   ProvisionService: vi.fn(() => mockProvisionInstance),
+}));
+
+vi.mock('../src/services/EmbeddingAgentService.js', () => ({
+  EmbeddingAgentService: vi.fn(() => mockEmbeddingInstance),
 }));
 
 import { registerRegistryRoutes } from '../src/routes/registry.js';
@@ -893,5 +903,177 @@ describe('orgSlug validation', () => {
 
     expect(res.statusCode).toBe(403);
     expect(res.json().error).toMatch(/orgSlug/);
+  });
+});
+
+// ── GET /v1/registry/embedding-providers ──────────────────────────────────
+
+describe('GET /v1/registry/embedding-providers', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildApp();
+  });
+
+  afterEach(async () => { await app.close(); });
+
+  it('returns provider list when system embedder is configured', async () => {
+    mockEmbeddingInstance.resolveEmbedder.mockResolvedValue({
+      provider: 'openai',
+      model: 'text-embedding-3-small',
+      dimensions: 1536,
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/registry/embedding-providers',
+      headers: { authorization: `Bearer ${readToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const json = res.json();
+    expect(json.providers).toHaveLength(1);
+    expect(json.providers[0]).toEqual({
+      name: 'system-embedder',
+      provider: 'openai',
+      model: 'text-embedding-3-small',
+    });
+  });
+
+  it('returns empty array when no embedder is configured', async () => {
+    mockEmbeddingInstance.resolveEmbedder.mockRejectedValue(
+      new Error('No embedding config available'),
+    );
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/registry/embedding-providers',
+      headers: { authorization: `Bearer ${readToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().providers).toEqual([]);
+  });
+
+  it('returns 401 when authorization header is missing', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/registry/embedding-providers' });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ── POST /v1/registry/embeddings ──────────────────────────────────────────
+
+describe('POST /v1/registry/embeddings', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildApp();
+  });
+
+  afterEach(async () => { await app.close(); });
+
+  it('returns embeddings for given texts', async () => {
+    mockEmbeddingInstance.resolveEmbedder.mockResolvedValue({
+      provider: 'openai',
+      model: 'text-embedding-3-small',
+      dimensions: 1536,
+      apiKey: 'sk-test',
+    });
+    mockEmbeddingInstance.embedTexts.mockResolvedValue({
+      embeddings: [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+      model: 'text-embedding-3-small',
+      dimensions: 1536,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/registry/embeddings',
+      headers: {
+        authorization: `Bearer ${readToken}`,
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({ texts: ['chunk 1', 'chunk 2'] }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const json = res.json();
+    expect(json.embeddings).toHaveLength(2);
+    expect(json.model).toBe('text-embedding-3-small');
+    expect(json.dimensions).toBe(1536);
+    expect(mockEmbeddingInstance.embedTexts).toHaveBeenCalledWith(
+      ['chunk 1', 'chunk 2'],
+      expect.objectContaining({ provider: 'openai', model: 'text-embedding-3-small' }),
+    );
+  });
+
+  it('returns 400 when texts array is empty', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/registry/embeddings',
+      headers: {
+        authorization: `Bearer ${readToken}`,
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({ texts: [] }),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/non-empty array/i);
+  });
+
+  it('returns 400 when texts field is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/registry/embeddings',
+      headers: {
+        authorization: `Bearer ${readToken}`,
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({}),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/non-empty array/i);
+  });
+
+  it('returns 401 when authorization header is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/registry/embeddings',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ texts: ['hello'] }),
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('accepts deploy:write scope for embeddings', async () => {
+    mockEmbeddingInstance.resolveEmbedder.mockResolvedValue({
+      provider: 'openai',
+      model: 'text-embedding-3-small',
+      dimensions: 1536,
+    });
+    mockEmbeddingInstance.embedTexts.mockResolvedValue({
+      embeddings: [[0.1, 0.2]],
+      model: 'text-embedding-3-small',
+      dimensions: 1536,
+    });
+
+    // Note: artifact:read is currently the required scope; deploy:write tokens
+    // do not have artifact:read, so they get 403 unless the route allows both.
+    // The current implementation uses artifact:read scope.
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/registry/embeddings',
+      headers: {
+        authorization: `Bearer ${deployToken}`,
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({ texts: ['hello'] }),
+    });
+
+    // deploy:write token lacks artifact:read scope, so 403 is expected
+    expect(res.statusCode).toBe(403);
   });
 });

--- a/tests/registry-routes.test.ts
+++ b/tests/registry-routes.test.ts
@@ -956,6 +956,20 @@ describe('GET /v1/registry/embedding-providers', () => {
     expect(res.json().providers).toEqual([]);
   });
 
+  it('returns 500 when resolveEmbedder throws an unexpected error', async () => {
+    mockEmbeddingInstance.resolveEmbedder.mockRejectedValue(
+      new Error('Connection refused'),
+    );
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/registry/embedding-providers',
+      headers: { authorization: `Bearer ${readToken}` },
+    });
+
+    expect(res.statusCode).toBe(500);
+  });
+
   it('returns 401 when authorization header is missing', async () => {
     const res = await app.inject({ method: 'GET', url: '/v1/registry/embedding-providers' });
     expect(res.statusCode).toBe(401);
@@ -1038,6 +1052,36 @@ describe('POST /v1/registry/embeddings', () => {
     expect(res.json().error).toMatch(/non-empty array/i);
   });
 
+  it('returns 400 when texts contains a non-string element', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/registry/embeddings',
+      headers: {
+        authorization: `Bearer ${readToken}`,
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({ texts: ['hello', 42] }),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/texts\[1\] is not a string/);
+  });
+
+  it('returns 400 when texts contains only whitespace strings', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/registry/embeddings',
+      headers: {
+        authorization: `Bearer ${readToken}`,
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({ texts: ['  ', '\t', ''] }),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/non-empty string/i);
+  });
+
   it('returns 401 when authorization header is missing', async () => {
     const res = await app.inject({
       method: 'POST',
@@ -1048,7 +1092,7 @@ describe('POST /v1/registry/embeddings', () => {
     expect(res.statusCode).toBe(401);
   });
 
-  it('accepts deploy:write scope for embeddings', async () => {
+  it('rejects deploy:write scope for embedding-providers', async () => {
     mockEmbeddingInstance.resolveEmbedder.mockResolvedValue({
       provider: 'openai',
       model: 'text-embedding-3-small',


### PR DESCRIPTION
## Summary
- Added `GET /v1/registry/embedding-providers` endpoint: returns available embedding providers for the tenant
- Added `POST /v1/registry/embeddings` endpoint: accepts texts, returns embeddings via the gateway's configured embedding provider
- Updated CLI `arachne weave` to discover and use gateway providers when no local embedding config exists
- If multiple providers available, prompts user to select
- If single provider, auto-selects with a message
- Falls back to existing local config (spec.embedder, env vars) for backward compatibility

## Priority order for embedding resolution
1. `spec.embedder` in KB YAML (local)
2. `ARACHNE_EMBED_*` env vars (local)
3. `SYSTEM_EMBEDDER_*` env vars (local)
4. **Gateway providers** (new: queries gateway, prompts if multiple)

## Test plan
- [x] Gateway: provider list, empty when unconfigured, 401, scope enforcement
- [x] Gateway: embeddings proxy happy path, empty texts 400, auth
- [x] CLI: discovery success/error/unreachable, embed via gateway, null fallback
- [x] `npm run build` passes
- [x] `npm test` passes

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)