### PR TITLE
fix: guard KB delete against existing deployments

### DIFF
--- a/src/routes/portal.ts
+++ b/src/routes/portal.ts
@@ -1505,6 +1505,20 @@ export function registerPortalRoutes(
       const { Artifact } = await import('../domain/entities/Artifact.js');
       const artifact = await em.findOne(Artifact, { id, tenant: tenantId, kind: 'KnowledgeBase' }, { populate: ['tags'] });
       if (!artifact) return reply.code(404).send({ error: 'Knowledge base not found' });
+      // Check for deployments referencing this artifact
+      const { Deployment } = await import('../domain/entities/Deployment.js');
+      const deployments = await em.find(Deployment, { artifact: artifact.id });
+      if (deployments.length > 0) {
+        return reply.code(409).send({
+          error: `Cannot delete knowledge base: it has ${deployments.length} active deployment(s). Remove them first.`,
+          deployments: deployments.map((d) => ({
+            id: d.id,
+            name: d.name,
+            environment: d.environment,
+            status: d.status,
+          })),
+        });
+      }
       // Remove all chunks then the artifact and its tags
       const { KbChunk } = await import('../domain/entities/KbChunk.js');
       const chunks = await em.find(KbChunk, { artifact: artifact.id });

--- a/src/routes/portal.ts
+++ b/src/routes/portal.ts
@@ -1507,10 +1507,10 @@ export function registerPortalRoutes(
       if (!artifact) return reply.code(404).send({ error: 'Knowledge base not found' });
       // Check for deployments referencing this artifact
       const { Deployment } = await import('../domain/entities/Deployment.js');
-      const deployments = await em.find(Deployment, { artifact: artifact.id });
+      const deployments = await em.find(Deployment, { artifact: artifact.id, tenant: tenantId });
       if (deployments.length > 0) {
         return reply.code(409).send({
-          error: `Cannot delete knowledge base: it has ${deployments.length} active deployment(s). Remove them first.`,
+          error: `Cannot delete knowledge base: it has ${deployments.length} deployment(s). Remove them first.`,
           deployments: deployments.map((d) => ({
             id: d.id,
             name: d.name,

--- a/tests/portal-kb-routes.test.ts
+++ b/tests/portal-kb-routes.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Fastify from 'fastify';
 import type { FastifyInstance } from 'fastify';
 import { signJwt } from '../src/auth/jwtUtils.js';
+import { Deployment } from '../src/domain/entities/Deployment.js';
 
 // ── Hoisted mocks (must run before module imports) ───────────────────────────
 
@@ -306,10 +307,10 @@ describe('DELETE /v1/portal/knowledge-bases/:id', () => {
     expect(res.json<{ error: string }>().error).toContain('not found');
   });
 
-  it('returns 409 when knowledge base has active deployments', async () => {
+  it('returns 409 when knowledge base has deployments', async () => {
     mockEm.findOne.mockResolvedValue(mockKbArtifact);
     mockEm.find.mockImplementation(async (entity: any) => {
-      if (entity?.name === 'Deployment' || entity?.toString?.().includes('Deployment')) {
+      if (entity === Deployment) {
         return [{ id: 'dep-1', name: 'oracle-cards-prod', environment: 'production', status: 'READY' }];
       }
       return [];
@@ -323,7 +324,8 @@ describe('DELETE /v1/portal/knowledge-bases/:id', () => {
 
     expect(res.statusCode).toBe(409);
     const body = res.json();
-    expect(body.error).toContain('active deployment');
+    expect(body.error).toContain('deployment(s)');
+
     expect(body.deployments).toHaveLength(1);
     expect(body.deployments[0]).toEqual({
       id: 'dep-1',

--- a/tests/portal-kb-routes.test.ts
+++ b/tests/portal-kb-routes.test.ts
@@ -306,6 +306,34 @@ describe('DELETE /v1/portal/knowledge-bases/:id', () => {
     expect(res.json<{ error: string }>().error).toContain('not found');
   });
 
+  it('returns 409 when knowledge base has active deployments', async () => {
+    mockEm.findOne.mockResolvedValue(mockKbArtifact);
+    mockEm.find.mockImplementation(async (entity: any) => {
+      if (entity?.name === 'Deployment' || entity?.toString?.().includes('Deployment')) {
+        return [{ id: 'dep-1', name: 'oracle-cards-prod', environment: 'production', status: 'READY' }];
+      }
+      return [];
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/v1/portal/knowledge-bases/${TEST_KB_ID}`,
+      headers: { authorization: `Bearer ${authToken()}` },
+    });
+
+    expect(res.statusCode).toBe(409);
+    const body = res.json();
+    expect(body.error).toContain('active deployment');
+    expect(body.deployments).toHaveLength(1);
+    expect(body.deployments[0]).toEqual({
+      id: 'dep-1',
+      name: 'oracle-cards-prod',
+      environment: 'production',
+      status: 'READY',
+    });
+    expect(mockEm.flush).not.toHaveBeenCalled();
+  });
+
   it('returns 401 without an auth token', async () => {
     const res = await app.inject({
       method: 'DELETE',


### PR DESCRIPTION
## Summary

- Check for deployments referencing the KB artifact before deleting
- Return 409 with deployment details (id, name, environment, status) when deployments exist
- Prevents raw FK constraint error that was surfacing as an unhandled database error

## Test plan

- [x] New test: 409 when KB has active deployments (verifies error message + deployment details)
- [x] Existing test: 200 with deleted:true still passes
- [x] `npm run build` passes
- [x] All 841 tests pass

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)