### PR TITLE
Switch to MikroORM migrator for new schema migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ npx vitest run tests/auth.test.ts
 npx vitest run -t "should resolve tenant context"
 ```
 
-### Database Migrations
+### Database Migrations (MikroORM)
 ```bash
 # Run pending migrations
 npm run migrate:up
@@ -116,8 +116,20 @@ npm run migrate:up
 # Rollback last migration
 npm run migrate:down
 
-# Create new migration
-npm run migrate:create <name>
+# Create new migration (auto-diffs entity schemas)
+npm run migrate:create
+
+# Check if schema is in sync with entities
+npm run migrate:check
+
+# List pending migrations
+npm run migrate:pending
+```
+
+### Legacy Migrations (node-pg-migrate, for rollback only)
+```bash
+npm run legacy:migrate:up
+npm run legacy:migrate:down
 ```
 
 ### Frontend Development
@@ -349,11 +361,13 @@ When adding a new provider:
 4. Handle provider-specific auth headers and error formats
 
 ### Migration Strategy
-Migrations are CommonJS (`.cjs`) using `node-pg-migrate`:
-- Create new migration: `npm run migrate:create descriptive-name`
-- Always provide both `up` and `down` functions
-- Test rollback (`migrate:down`) before committing
-- Use parameterized queries (`$1`, `$2`) for SQL injection safety
+New migrations use **MikroORM's migrator** (TypeScript files in `src/migrations/`):
+- Create new migration: `npm run migrate:create` (auto-diffs entity schemas against snapshot)
+- Review generated SQL before applying
+- Apply with `npm run migrate:up`, roll back with `npm run migrate:down`
+- The migrator uses a separate `mikro_orm_migrations` table for its history
+- Legacy `node-pg-migrate` migrations (CommonJS `.cjs` in `migrations/`) are kept for rollback only
+- See `docs/developer-guide.md` for the full migration workflow
 
 ### Frontend Serving
 Both Portal and Dashboard are served as static SPAs by Fastify:

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -231,6 +231,93 @@ Arachne proxies OpenAI's `/v1/chat/completions` endpoint with the following exte
 **Frontend:**
 - Vite + React (Portal and Dashboard SPAs)
 
+## Database Migrations
+
+Arachne uses **MikroORM's migrator** for all new schema changes. The legacy
+`node-pg-migrate` tool is retained as a fallback for rolling back historical
+migrations (001 through 027).
+
+### Quick Reference
+
+```bash
+# Apply all pending migrations
+npm run migrate:up
+
+# Roll back the last MikroORM migration
+npm run migrate:down
+
+# Create a new migration (auto-diffs entity schemas)
+npm run migrate:create
+
+# Check if schema is in sync with entities
+npm run migrate:check
+
+# List pending (unapplied) migrations
+npm run migrate:pending
+```
+
+### How It Works
+
+1. MikroORM compares your `EntitySchema` definitions (in `src/domain/schemas/`)
+   against a snapshot file and generates a TypeScript migration in `src/migrations/`.
+2. The migrator stores its history in the `mikro_orm_migrations` table (separate
+   from the legacy `pgmigrations` table used by node-pg-migrate).
+3. A baseline migration (`Migration00000000000000_baseline`) marks the boundary:
+   everything before it was created by node-pg-migrate; everything after uses
+   MikroORM migrations.
+
+### Creating a New Migration
+
+```bash
+# 1. Edit or add EntitySchema files in src/domain/schemas/
+# 2. Auto-generate the migration:
+npm run migrate:create
+
+# 3. Review the generated file in src/migrations/
+# 4. Apply it:
+npm run migrate:up
+```
+
+The generated migration will contain the SQL diff between the current snapshot
+and your updated entity schemas. Always review the generated SQL before applying.
+
+### Setting Up a Fresh Database
+
+For a brand-new database, run the legacy migrations first to create the base
+schema, then apply MikroORM migrations for any changes after the baseline:
+
+```bash
+npm run legacy:migrate:up   # Apply node-pg-migrate migrations 001-027
+npm run migrate:up           # Apply MikroORM migrations (baseline + newer)
+```
+
+### Legacy Fallback (node-pg-migrate)
+
+The original 27 migrations remain in the `migrations/` directory. Legacy
+commands are available under the `legacy:` prefix:
+
+```bash
+npm run legacy:migrate:up      # Run pending legacy migrations
+npm run legacy:migrate:down    # Roll back last legacy migration
+npm run legacy:migrate:create  # Create a new legacy migration (not recommended)
+```
+
+Use these only for rolling back pre-baseline schema changes.
+
+### Configuration
+
+The migrator is configured in `src/orm.ts` (via `buildOrmConfig()`) and exposed
+to the CLI through `mikro-orm.config.ts` at the project root. Key settings:
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| `migrations.path` | `./src/migrations` | Where migration files live |
+| `migrations.tableName` | `mikro_orm_migrations` | History table (separate from legacy) |
+| `migrations.snapshot` | `true` | Enables schema diffing for auto-generated migrations |
+| `migrations.emit` | `ts` | Generates TypeScript migration files |
+| `migrations.transactional` | `true` | Each migration runs in a transaction |
+| `migrations.allOrNothing` | `true` | Batch execution rolls back on any failure |
+
 ## Database Schema
 
 ### Core Tables

--- a/mikro-orm.config.ts
+++ b/mikro-orm.config.ts
@@ -1,0 +1,12 @@
+/**
+ * MikroORM CLI configuration.
+ *
+ * Used by `npx mikro-orm` commands (migration:create, migration:up, etc.).
+ * Delegates to the shared buildOrmConfig() so runtime and CLI always agree.
+ *
+ * Requires `dotenv` to load .env before MikroORM reads DATABASE_URL.
+ */
+import 'dotenv/config';
+import { buildOrmConfig } from './src/orm.js';
+
+export default buildOrmConfig();

--- a/package.json
+++ b/package.json
@@ -7,10 +7,17 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "tsx scripts/backfill-sandbox-keys.ts && node dist/index.js",
-    "migrate": "node-pg-migrate",
-    "migrate:up": "node-pg-migrate up",
-    "migrate:down": "node-pg-migrate down",
-    "migrate:create": "node-pg-migrate create",
+    "migrate": "mikro-orm-esm migration:up",
+    "migrate:up": "mikro-orm-esm migration:up",
+    "migrate:down": "mikro-orm-esm migration:down",
+    "migrate:create": "mikro-orm-esm migration:create",
+    "migrate:check": "mikro-orm-esm migration:check",
+    "migrate:pending": "mikro-orm-esm migration:pending",
+    "migrate:fresh": "mikro-orm-esm migration:fresh",
+    "legacy:migrate": "node-pg-migrate",
+    "legacy:migrate:up": "node-pg-migrate up",
+    "legacy:migrate:down": "node-pg-migrate down",
+    "legacy:migrate:create": "node-pg-migrate create",
     "test": "vitest run --project arachne --project loom-portal",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -38,6 +45,7 @@
   "author": "Michael Brown",
   "license": "MIT",
   "devDependencies": {
+    "@mikro-orm/cli": "^6.6.7",
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
     "@testing-library/jest-dom": "^6.9.1",
@@ -76,5 +84,11 @@
     "cli",
     "packages/chat",
     "site"
-  ]
+  ],
+  "mikro-orm": {
+    "useTsNode": true,
+    "configPaths": [
+      "./mikro-orm.config.ts"
+    ]
+  }
 }

--- a/src/migrations/Migration00000000000000_baseline.ts
+++ b/src/migrations/Migration00000000000000_baseline.ts
@@ -1,0 +1,36 @@
+import { Migration } from '@mikro-orm/migrations';
+
+/**
+ * Baseline migration: represents the cumulative schema created by
+ * node-pg-migrate migrations 001 through 027.
+ *
+ * This migration is intentionally a no-op. On existing databases the
+ * schema already exists (applied via node-pg-migrate). On fresh databases
+ * the full schema should be created by running `npm run legacy:migrate:up`
+ * first, then marking this baseline as applied.
+ *
+ * After this baseline, all new schema changes use MikroORM migrations.
+ *
+ * Covered tables (from node-pg-migrate history):
+ *   tenants, api_keys, traces (partitioned), admin_users, users,
+ *   tenant_memberships, invites, agents, conversations,
+ *   conversation_messages, conversation_snapshots, artifacts,
+ *   artifact_tags, knowledge_base_chunks, vector_spaces, deployments,
+ *   beta_signups, settings, providers, provider_tenant_access,
+ *   smoke_test_runs, partitions
+ */
+export class Migration00000000000000_baseline extends Migration {
+  override async up(): Promise<void> {
+    // No-op: schema already exists via node-pg-migrate migrations.
+    // This migration exists solely as a baseline marker so that
+    // MikroORM's migrator knows where its history begins.
+  }
+
+  override async down(): Promise<void> {
+    // Rolling back the baseline is not supported.
+    // Use node-pg-migrate (npm run legacy:migrate:down) for legacy rollbacks.
+    throw new Error(
+      'Cannot roll back baseline migration. Use node-pg-migrate for legacy schema rollbacks.'
+    );
+  }
+}

--- a/src/orm.ts
+++ b/src/orm.ts
@@ -1,6 +1,7 @@
 import { MikroORM, type Options } from '@mikro-orm/core';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
+import { Migrator } from '@mikro-orm/migrations';
 import { allSchemas } from './domain/schemas/index.js';
 
 const DRIVER_MAP = {
@@ -10,7 +11,11 @@ const DRIVER_MAP = {
 
 type DriverType = keyof typeof DRIVER_MAP;
 
-export async function initOrm(overrides?: Partial<Options>): Promise<MikroORM> {
+/**
+ * Build the shared MikroORM configuration object.
+ * Exported so that mikro-orm.config.ts (CLI entry point) can reuse it.
+ */
+export function buildOrmConfig(overrides?: Partial<Options>): Options {
   const driverType = (process.env.DB_DRIVER ?? 'postgres') as DriverType;
   const driver = DRIVER_MAP[driverType] ?? PostgreSqlDriver;
 
@@ -18,17 +23,29 @@ export async function initOrm(overrides?: Partial<Options>): Promise<MikroORM> {
     process.env.DATABASE_URL ?? 'postgres://loom:loom_dev_password@localhost:5432/loom';
   const useSSL = clientUrl.includes('sslmode=require') || clientUrl.includes('sslmode=verify');
 
-  const config: Options = {
+  return {
     driver,
     clientUrl,
     entities: allSchemas,
     debug: process.env.NODE_ENV === 'development',
+    extensions: [Migrator],
+    migrations: {
+      path: './src/migrations',
+      tableName: 'mikro_orm_migrations',
+      transactional: true,
+      allOrNothing: true,
+      snapshot: true,
+      emit: 'ts',
+    },
     ...(useSSL && driverType === 'postgres'
       ? { driverOptions: { connection: { ssl: { rejectUnauthorized: false } } } }
       : {}),
     ...overrides,
   };
+}
 
+export async function initOrm(overrides?: Partial<Options>): Promise<MikroORM> {
+  const config = buildOrmConfig(overrides);
   const instance = await MikroORM.init(config);
   orm = instance;
   return instance;


### PR DESCRIPTION
## Summary
- Configured MikroORM migrator in `src/orm.ts` with extracted `buildOrmConfig()` function
- Created CLI entry point at `mikro-orm.config.ts` sharing runtime config
- Added no-op baseline migration as boundary marker between legacy and new migrations
- Updated npm scripts: `migrate:*` now use `mikro-orm-esm`, legacy commands preserved as `legacy:migrate:*`
- Added `@mikro-orm/cli` dev dependency
- Updated `docs/developer-guide.md` and `CLAUDE.md` with new migration workflow

## Test plan
- [x] All 852 backend tests pass
- [ ] Run `npm run migrate:pending` against a fresh database to verify baseline detection
- [ ] Run `npm run migrate:create test` to verify auto-diff generates correct SQL
- [ ] Verify `npm run legacy:migrate:down` still works for historical rollbacks

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)