### PR TITLE
docs: add system specs batch (April 2026)

### DIFF
--- a/docs/gcp_migration_spec.md
+++ b/docs/gcp_migration_spec.md
@@ -1,0 +1,462 @@
+# Arachne — Azure to GCP Migration Spec
+
+**Author:** Michael Brown, CEO
+**Date:** 2026-04-28
+**Status:** Planning
+**Version:** 0.1
+
+---
+
+## 1. Overview
+
+Migrate all Arachne infrastructure from Microsoft Azure to Google Cloud Platform. Synaptic Weave's Azure for Startups credits have lapsed; GCP is now the primary cloud provider via Google Cloud for Startups ($25K credits) and the Google Cloud Partner Program.
+
+**Target GCP project:** TBD (create `arachne-prod` and `arachne-dev`)
+**Target region:** `us-central1` (consistent with Calliope)
+**Deadline:** Before Azure resources are suspended
+
+---
+
+## 2. Service Mapping
+
+| Component | Azure (current) | GCP (target) |
+|-----------|----------------|--------------|
+| Container runtime | Azure Container Apps | Cloud Run |
+| PostgreSQL database | Azure Database for PostgreSQL Flexible Server | Cloud SQL (PostgreSQL 16) |
+| Secrets management | Azure Key Vault | Secret Manager |
+| Observability | Azure Log Analytics + App Insights | Cloud Logging + Cloud Monitoring |
+| Static site / CDN | Azure Static Web Apps | Firebase Hosting |
+| Terraform state | Azure Blob Storage | GCS bucket |
+| CI/CD identity | Azure AD service principal | Workload Identity Federation |
+| Managed identity | Azure User-Assigned Managed Identity | GCP Service Account |
+| DNS | Azure DNS Zones | Cloud DNS (or keep at current registrar) |
+| Container registry | GHCR (unchanged) | GHCR (unchanged) |
+
+---
+
+## 3. Current Azure Architecture
+
+### Resources (from Terraform)
+
+**Compute:**
+- Azure Container Apps environment
+- Gateway container app (`arachne-gateway`)
+- Portal container app (`arachne-portal`)
+- Smoke runner sidecar
+
+**Database:**
+- PostgreSQL Flexible Server, v15, SKU: `B_Standard_B1ms`
+- 32 GB storage
+- Admin login: `arachneadmin`
+- pgvector extension enabled
+
+**Secrets (Key Vault):**
+- `database-url` — full PostgreSQL connection string
+- `master-key` — AES-256-GCM encryption master key (64-char hex)
+- `jwt-secret` — Portal JWT signing secret
+- `admin-jwt-secret` — Admin JWT signing secret
+- `db-admin-password` — PostgreSQL admin password
+
+**Networking:**
+- DNS zones: `arachne-ai.com`, `arachne-ai.dev`
+- CORS origin: `https://arachne-ai.com`
+- Gateway and portal exposed via custom domains
+
+**CI/CD:**
+- Azure AD service principal with Contributor role
+- GitHub Actions federated identity
+
+**Observability:**
+- Log Analytics workspace
+- Linked to Container Apps environment
+
+---
+
+## 4. Target GCP Architecture
+
+### 4.1 Compute — Cloud Run
+
+Both gateway and portal run as Cloud Run services.
+
+| Service | Image | Port | Auth |
+|---------|-------|------|------|
+| `arachne-gateway` | `ghcr.io/synaptic-weave/arachne-gateway:latest` | 3000 | Public (API key auth in app) |
+| `arachne-portal` | `ghcr.io/synaptic-weave/arachne-portal:latest` | 3000 | Public |
+
+**Cloud Run config per service:**
+- Region: `us-central1`
+- Min instances: 0 (dev), 1 (prod)
+- Max instances: 10
+- CPU: 1
+- Memory: 512Mi (portal), 1Gi (gateway)
+- Concurrency: 80
+- Service account: `arachne-runtime@{project}.iam.gserviceaccount.com`
+
+**GHCR auth:** Cloud Run pulls from GHCR using a GitHub PAT stored in Secret Manager, referenced at deploy time.
+
+### 4.2 Database — Cloud SQL
+
+| Setting | Value |
+|---------|-------|
+| Engine | PostgreSQL 16 |
+| Instance tier | `db-f1-micro` (dev), `db-g1-small` (prod) |
+| Region | `us-central1` |
+| Storage | 32 GB SSD, auto-grow enabled |
+| Backups | Daily automated, 7-day retention |
+| Extensions | `pgvector` (enable via database flags) |
+| Connectivity | Private IP via VPC connector (no public IP in prod) |
+| SSL | Required |
+
+**Database name:** `arachne`
+**Admin user:** `arachneadmin`
+
+### 4.3 Secrets — Secret Manager
+
+| Secret Name | Value |
+|-------------|-------|
+| `arachne-database-url` | `postgresql://arachneadmin:{password}@{cloud-sql-ip}:5432/arachne?sslmode=require` |
+| `arachne-master-key` | 64-char hex (regenerate or copy from Key Vault) |
+| `arachne-portal-jwt-secret` | JWT signing secret |
+| `arachne-admin-jwt-secret` | Admin JWT signing secret |
+| `arachne-db-admin-password` | PostgreSQL admin password |
+| `arachne-ghcr-token` | GitHub PAT for GHCR pulls |
+
+Service account `arachne-runtime` granted `roles/secretmanager.secretAccessor`.
+
+### 4.4 Networking — VPC + Serverless VPC Connector
+
+```
+VPC: arachne-vpc
+  Subnet: arachne-subnet (10.0.0.0/24, us-central1)
+  Serverless VPC Connector: arachne-connector
+    → Connects Cloud Run to Cloud SQL private IP
+    → Range: 10.8.0.0/28
+```
+
+Cloud SQL uses private IP only (prod). Cloud Run services access it via the VPC connector.
+
+### 4.5 Observability — Cloud Logging + Monitoring
+
+- Cloud Run logs automatically flow to Cloud Logging
+- Create log-based metrics for error rates and latency
+- Uptime checks for gateway and portal URLs
+- Alert policies: error rate > 1%, p95 latency > 2s
+
+### 4.6 Static Site — Firebase Hosting
+
+Portal SPA served via Firebase Hosting:
+- Custom domain: `arachne-ai.com` (gateway), `app.arachne-ai.com` (portal)
+- Firebase Hosting handles SSL and CDN automatically
+- Deploy via `firebase deploy` in CI/CD
+
+Alternatively: Cloud Run with `@fastify/static` already serves the portal SPA — Firebase Hosting may be unnecessary if the portal container handles static serving.
+
+**Decision:** Use Cloud Run for portal (already containerized, simpler). Firebase Hosting only if CDN performance becomes a concern.
+
+### 4.7 CI/CD — Workload Identity Federation
+
+Replace Azure AD service principal with GCP Workload Identity Federation for GitHub Actions.
+
+```
+GitHub Actions OIDC → GCP Workload Identity Pool
+  → Service account: arachne-cicd@{project}.iam.gserviceaccount.com
+  → Roles: Cloud Run Admin, Artifact Registry Reader, Secret Manager Accessor
+```
+
+No long-lived credentials stored in GitHub. Token is minted per workflow run.
+
+### 4.8 Terraform State — GCS
+
+```
+Bucket: gs://arachne-tfstate-{project-id}
+  Location: us-central1
+  Versioning: enabled
+  Uniform bucket-level access: enabled
+```
+
+---
+
+## 5. Terraform Migration Plan
+
+### 5.1 Module Replacements
+
+| Current Azure Module | New GCP Module |
+|---------------------|----------------|
+| `modules/observability` (Log Analytics) | `modules/observability` (Cloud Logging metrics + alerts) |
+| `modules/keyvault` | `modules/secrets` (Secret Manager) |
+| `modules/database` (Azure PostgreSQL) | `modules/database` (Cloud SQL) |
+| `modules/container_apps` | `modules/cloud_run` |
+| `modules/static_site` (Azure Static Web Apps) | Remove (Cloud Run serves portal) |
+| `modules/cicd` (Azure AD SP) | `modules/cicd` (Workload Identity Federation) |
+
+### 5.2 New Root Providers
+
+```hcl
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "arachne-tfstate-{project-id}"
+    prefix = "terraform/state"
+  }
+}
+```
+
+### 5.3 New Variables
+
+| Variable | Description |
+|----------|-------------|
+| `project_id` | GCP project ID (`arachne-prod` or `arachne-dev`) |
+| `region` | GCP region (default: `us-central1`) |
+| `environment` | `dev` or `prod` |
+| `ghcr_owner` | GitHub org (unchanged: `synaptic-weave`) |
+| `db_tier` | Cloud SQL tier |
+| `allowed_origins` | CORS origins |
+
+---
+
+## 6. Database Migration
+
+### 6.1 Export from Azure PostgreSQL
+
+```bash
+# On a machine with access to Azure PostgreSQL
+pg_dump \
+  --host={azure-fqdn} \
+  --username=arachneadmin \
+  --dbname=arachne \
+  --format=custom \
+  --no-owner \
+  --no-acl \
+  --file=arachne_dump.pgdump
+```
+
+### 6.2 Enable pgvector on Cloud SQL
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+Add to Terraform database module:
+```hcl
+resource "google_sql_database" "arachne" {
+  name     = "arachne"
+  instance = google_sql_database_instance.main.name
+}
+```
+
+Database flags:
+```hcl
+database_flags {
+  name  = "cloudsql.enable_pgvector"
+  value = "on"
+}
+```
+
+### 6.3 Import to Cloud SQL
+
+```bash
+# Via Cloud SQL proxy
+cloud-sql-proxy {project}:us-central1:arachne-db &
+
+pg_restore \
+  --host=127.0.0.1 \
+  --port=5432 \
+  --username=arachneadmin \
+  --dbname=arachne \
+  --no-owner \
+  arachne_dump.pgdump
+```
+
+### 6.4 Verify
+
+```bash
+# Check row counts match
+psql -c "SELECT schemaname, tablename, n_live_tup FROM pg_stat_user_tables ORDER BY n_live_tup DESC;"
+
+# Check pgvector is working
+psql -c "SELECT * FROM pg_extension WHERE extname = 'vector';"
+```
+
+---
+
+## 7. DNS Migration
+
+Current DNS zones on Azure: `arachne-ai.com`, `arachne-ai.dev`
+
+**Options:**
+1. **Keep at current registrar, update A records** — simplest, no zone migration needed
+2. **Migrate zones to Cloud DNS** — cleaner long-term, manageable via Terraform
+
+**Recommendation:** Migrate to Cloud DNS for Terraform-managed DNS. Export current zone records first.
+
+### DNS Records (target)
+
+| Record | Type | Value |
+|--------|------|-------|
+| `arachne-ai.com` | A | Cloud Run gateway IP (via load balancer) |
+| `app.arachne-ai.com` | A | Cloud Run portal IP |
+| `arachne-ai.dev` | A | Dev environment Cloud Run IP |
+
+**Note:** Cloud Run services get a `*.run.app` URL by default. Custom domains require a Global Load Balancer + managed SSL cert or Firebase Hosting.
+
+---
+
+## 8. Secrets Migration
+
+Secrets cannot be copied programmatically from Azure Key Vault to GCP Secret Manager (by design). Manual steps:
+
+1. Read each secret value from Azure Key Vault (portal or `az keyvault secret show`)
+2. Create corresponding secret in GCP Secret Manager
+3. Do NOT regenerate `master-key` — existing encrypted data in the database requires the same key
+
+**Critical:** The `master-key` must be copied exactly. Regenerating it will make all encrypted trace data and conversation messages unreadable.
+
+```bash
+# Read from Azure (while access still available)
+az keyvault secret show --vault-name kv-arachne-prod --name master-key --query value -o tsv
+
+# Write to GCP
+echo -n "{value}" | gcloud secrets create arachne-master-key \
+  --data-file=- \
+  --replication-policy=automatic
+```
+
+---
+
+## 9. CI/CD Migration
+
+### Current (Azure)
+GitHub Actions authenticates to Azure using a service principal with federated OIDC credentials.
+
+### Target (GCP Workload Identity Federation)
+
+```bash
+# Create Workload Identity Pool
+gcloud iam workload-identity-pools create github-pool \
+  --location=global \
+  --display-name="GitHub Actions Pool"
+
+# Create provider
+gcloud iam workload-identity-pools providers create-oidc github-provider \
+  --location=global \
+  --workload-identity-pool=github-pool \
+  --issuer-uri=https://token.actions.githubusercontent.com \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository"
+
+# Bind to service account
+gcloud iam service-accounts add-iam-policy-binding \
+  arachne-cicd@{project}.iam.gserviceaccount.com \
+  --role=roles/iam.workloadIdentityUser \
+  --member="principalSet://iam.googleapis.com/projects/{project-number}/locations/global/workloadIdentityPools/github-pool/attribute.repository/synaptic-weave/arachne"
+```
+
+### GitHub Actions workflow changes
+
+Replace `azure/login` action with `google-github-actions/auth`:
+
+```yaml
+- uses: google-github-actions/auth@v2
+  with:
+    workload_identity_provider: projects/{number}/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+    service_account: arachne-cicd@{project}.iam.gserviceaccount.com
+```
+
+---
+
+## 10. Migration Sequence
+
+Execute in this order to minimize downtime:
+
+### Phase 1: Foundations (no downtime)
+- [ ] Create GCP projects (`arachne-prod`, `arachne-dev`)
+- [ ] Enable required APIs (Cloud Run, Cloud SQL, Secret Manager, etc.)
+- [ ] Create GCS bucket for Terraform state
+- [ ] Write new Terraform modules (GCP)
+- [ ] `terraform plan` — verify no errors
+
+### Phase 2: Database (maintenance window)
+- [ ] Export Azure PostgreSQL dump
+- [ ] Provision Cloud SQL instance via Terraform
+- [ ] Enable pgvector
+- [ ] Import dump
+- [ ] Verify row counts and pgvector functionality
+- [ ] Update `DATABASE_URL` secret to point to Cloud SQL
+
+### Phase 3: Secrets
+- [ ] Read all secrets from Azure Key Vault
+- [ ] Create all secrets in GCP Secret Manager
+- [ ] Verify Cloud Run service account has `secretAccessor` role
+
+### Phase 4: Compute
+- [ ] Deploy Cloud Run services via Terraform
+- [ ] Smoke test against `*.run.app` URLs
+- [ ] Verify gateway → database connectivity
+- [ ] Verify all secrets are injected correctly
+
+### Phase 5: DNS Cutover (brief downtime ~5 min)
+- [ ] Lower Azure DNS TTLs to 60s (do this 24h before cutover)
+- [ ] Create Cloud DNS zones
+- [ ] Update Cloud Run custom domain mappings
+- [ ] Update nameservers at registrar
+- [ ] Verify SSL certificates issued
+- [ ] Monitor error rates
+
+### Phase 6: CI/CD
+- [ ] Set up Workload Identity Federation
+- [ ] Update GitHub Actions workflows
+- [ ] Run a full deploy pipeline end-to-end
+- [ ] Verify smoke tests pass
+
+### Phase 7: Decommission Azure
+- [ ] Confirm all traffic is flowing through GCP
+- [ ] Run Azure resources in parallel for 48 hours (rollback window)
+- [ ] `terraform destroy` on Azure resources
+- [ ] Cancel Azure subscription / remove Synaptic Weave tenant
+
+---
+
+## 11. Rollback Plan
+
+If GCP migration fails after DNS cutover:
+
+1. Revert nameservers to Azure DNS
+2. Azure Container Apps are still running (do not destroy until Phase 7)
+3. Azure PostgreSQL is still running with original data
+4. DNS propagation: ~5 minutes (TTL was lowered to 60s)
+
+---
+
+## 12. Cost Estimate (GCP, monthly)
+
+| Service | Tier | Est. Monthly Cost |
+|---------|------|------------------|
+| Cloud Run (gateway + portal) | ~500K requests/mo | ~$5-15 |
+| Cloud SQL (db-g1-small) | 1 vCPU, 1.7GB RAM | ~$25-35 |
+| Cloud SQL storage (32GB SSD) | — | ~$6 |
+| Secret Manager | <10K accesses | ~$1 |
+| Cloud Logging | First 50GB free | $0 |
+| Cloud DNS | 1 zone | ~$1 |
+| GCS (Terraform state) | Negligible | ~$0 |
+| **Total** | | **~$38-58/mo** |
+
+Well within the $25K startup credits. Credits provide ~18-24 months of runway at this burn rate.
+
+---
+
+## 13. References
+
+- [Cloud Run docs](https://cloud.google.com/run/docs)
+- [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres)
+- [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+- [pgvector on Cloud SQL](https://cloud.google.com/sql/docs/postgres/extensions#vector)
+- [Terraform Google provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs)

--- a/docs/system_specs/agui_adoption_spec.md
+++ b/docs/system_specs/agui_adoption_spec.md
@@ -1,0 +1,630 @@
+# AG-UI Adoption Spec for Arachne
+
+> Comprehensive analysis of adopting the AG-UI protocol in both the Arachne runtime and the Portal chat React UI.
+
+**Status:** Draft
+**Author:** Oracle (AI Systems Advisor)
+**Last Updated:** 2026-04-01
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [AG-UI Protocol Overview](#2-ag-ui-protocol-overview)
+3. [Runtime Integration](#3-runtime-integration)
+4. [Portal Chat UI Integration](#4-portal-chat-ui-integration)
+5. [ACP vs A2A Analysis](#5-acp-vs-a2a-analysis)
+6. [Migration Strategy](#6-migration-strategy)
+7. [Risks & Mitigations](#7-risks--mitigations)
+8. [Decisions & Open Questions](#8-decisions--open-questions)
+
+---
+
+## 1. Executive Summary
+
+AG-UI is an open, event-based protocol (MIT license, by CopilotKit) that standardizes agent-to-frontend communication. It defines ~28 event types transmitted over SSE/WebSocket, covering streaming text, tool calls, state synchronization, HITL (human-in-the-loop) flows, reasoning visibility, and sub-agent delegation. Adopted by Google (ADK), Microsoft (Agent Framework), AWS (Bedrock AgentCore), and others.
+
+**Protocol positioning:** AG-UI completes the three-protocol stack for agentic systems:
+
+| Protocol | Axis | Arachne Status |
+|----------|------|----------------|
+| **MCP** | Agent ↔ Tools | Supported (tool-call round-trip in gateway) |
+| **ACP** | Agent ↔ Agent | Designed (v0.1 spec, internal) |
+| **AG-UI** | Agent ↔ Frontend | **This spec** |
+
+**Recommendation:** Adopt AG-UI as the Portal chat streaming protocol. Implement as a gateway-level SSE transform that wraps existing provider responses in AG-UI events. Tenants get AG-UI compatibility automatically -- no agent-level opt-in required. Use `@ag-ui/client` for the Portal chat consumer rather than pulling in the full CopilotKit React framework.
+
+---
+
+## 2. AG-UI Protocol Overview
+
+### 2.1 Event Taxonomy (28 event types)
+
+**Lifecycle events** -- bound an agent execution:
+
+| Event | Purpose |
+|-------|---------|
+| `RunStarted` | Opens a run context with `threadId` + `runId` |
+| `RunFinished` | Signals successful completion, optional `result` |
+| `RunError` | Terminal error with `message` + `code` |
+| `StepStarted` | Marks a discrete processing phase (maps to sub-agent invocation) |
+| `StepFinished` | Closes the step |
+
+**Text message events** -- streaming assistant responses:
+
+| Event | Purpose |
+|-------|---------|
+| `TextMessageStart` | Opens a message with `messageId` + `role` |
+| `TextMessageContent` | Delivers incremental text `delta` chunks |
+| `TextMessageEnd` | Closes the message |
+| `TextMessageChunk` | Convenience: auto-expands to Start/Content/End |
+
+**Tool call events** -- MCP round-trips surfaced to frontend:
+
+| Event | Purpose |
+|-------|---------|
+| `ToolCallStart` | Agent invokes a tool: `toolCallId` + `toolCallName` |
+| `ToolCallArgs` | Streams tool arguments as JSON delta fragments |
+| `ToolCallEnd` | Tool argument transmission complete |
+| `ToolCallResult` | Tool execution output (`content` field) |
+| `ToolCallChunk` | Convenience: auto-expands to Start/Args/End |
+
+**State events** -- bi-directional shared state:
+
+| Event | Purpose |
+|-------|---------|
+| `StateSnapshot` | Full state object replacement |
+| `StateDelta` | Incremental JSON Patch (RFC 6902) |
+| `MessagesSnapshot` | Full conversation history sync |
+
+**Activity events** -- structured progress indicators:
+
+| Event | Purpose |
+|-------|---------|
+| `ActivitySnapshot` | Structured activity state (e.g., plan, search) |
+| `ActivityDelta` | Incremental activity update via JSON Patch |
+
+**Reasoning events** -- thinking/chain-of-thought visibility:
+
+| Event | Purpose |
+|-------|---------|
+| `ReasoningStart` / `ReasoningEnd` | Bound a reasoning block |
+| `ReasoningMessageStart/Content/End/Chunk` | Stream reasoning text |
+| `ReasoningEncryptedValue` | Encrypted CoT for state preservation |
+
+**Extension events:**
+
+| Event | Purpose |
+|-------|---------|
+| `Raw` | Passthrough for external system events |
+| `Custom` | Application-defined event semantics |
+| `MetaEvent` (draft) | Side-band annotations independent of runs |
+
+### 2.2 Transport
+
+AG-UI events are transmitted as **Server-Sent Events (SSE)** over HTTP. The agent exposes a single endpoint that accepts `RunAgentInput` (containing `threadId`, `runId`, `tools[]`, `context`) and returns an SSE stream of typed events. WebSocket transport is supported as an alternative for bi-directional scenarios (state sync).
+
+### 2.3 Middleware
+
+AG-UI defines a middleware pipeline that intercepts and transforms event streams between agent and consumer. Middleware wraps in chain order (first registered = outermost). Two styles: function-based (RxJS operators) and class-based (stateful). This maps directly to Arachne's gateway transform pipeline.
+
+### 2.4 Frontend Tools
+
+A distinguishing AG-UI feature: **tools are defined in the frontend and passed to the agent at run time**. The agent can invoke frontend-defined tools (e.g., `confirmAction` for HITL) and the frontend executes them locally, returning results as tool messages. This enables HITL without server-side state machines.
+
+---
+
+## 3. Runtime Integration
+
+### 3.1 Architecture: Gateway-Level AG-UI Transform
+
+AG-UI adoption sits in the SSE streaming path of the gateway. The existing `src/streaming.ts` Transform stream that tees SSE data is extended with an AG-UI event emitter that wraps OpenAI-compatible SSE chunks in AG-UI event envelopes.
+
+```
+Client (Portal) ──POST /v1/chat/completions──> Gateway
+                                                  │
+                                         ┌────────┴────────┐
+                                         │ Auth + Agent     │
+                                         │ Engine + Memory  │
+                                         └────────┬────────┘
+                                                  │
+                                         Provider (upstream)
+                                                  │
+                                         SSE chunks back
+                                                  │
+                                    ┌─────────────┴──────────────┐
+                                    │ SSE Transform (existing)    │
+                                    │   ├── tee to client         │
+                                    │   ├── accumulate for trace  │
+                                    │   └── AG-UI event wrapper   │ ← NEW
+                                    └─────────────┬──────────────┘
+                                                  │
+                                    AG-UI SSE stream to client
+```
+
+**Key design decision:** AG-UI events are emitted at the **gateway level**, not at the agent or provider level. This means every tenant gets AG-UI compatibility automatically. No changes to agent specs, provider adapters, or upstream LLM calls.
+
+### 3.2 Event Mapping: OpenAI SSE → AG-UI Events
+
+The gateway's SSE Transform maps OpenAI-compatible streaming chunks to AG-UI events:
+
+| OpenAI SSE Event | AG-UI Event(s) | Mapping Logic |
+|---|---|---|
+| First `data:` chunk with `choices[0].delta.role` | `RunStarted` + `TextMessageStart` | Emit at stream open. `runId` = trace `requestId`. `threadId` = `conversationId` or generated. `messageId` = `choices[0].id` or generated UUID. |
+| `choices[0].delta.content` (non-empty) | `TextMessageContent` | `delta` = chunk content. `messageId` from Start event. |
+| `choices[0].delta.tool_calls[i]` (function name) | `ToolCallStart` | `toolCallId` = `tool_calls[i].id`. `toolCallName` = `function.name`. |
+| `choices[0].delta.tool_calls[i].function.arguments` | `ToolCallArgs` | `delta` = argument fragment. |
+| Tool call complete (no more argument deltas) | `ToolCallEnd` | Emitted when tool_call index changes or stream ends. |
+| MCP round-trip result injected back | `ToolCallResult` | `content` = MCP tool response. `toolCallId` matches the Start. |
+| `data: [DONE]` | `TextMessageEnd` + `RunFinished` | Close message and run. |
+| Provider error / timeout | `RunError` | `message` = error description. `code` = HTTP status or error type. |
+
+**Implementation sketch** (`src/streaming.ts` extension):
+
+```typescript
+interface AGUIStreamOptions {
+  enabled: boolean;        // Feature flag per request
+  threadId: string;        // From conversation ID or header
+  runId: string;           // From trace requestId
+}
+
+function emitAGUIEvent(res: FastifyReply, event: BaseEvent): void {
+  // AG-UI events are SSE `data:` lines with JSON payloads
+  res.raw.write(`data: ${JSON.stringify(event)}\n\n`);
+}
+```
+
+### 3.3 Activation Mechanism
+
+AG-UI streaming is activated per-request via an `Accept` header or query parameter:
+
+```
+POST /v1/chat/completions
+Accept: text/event-stream; protocol=ag-ui
+```
+
+Or:
+
+```
+POST /v1/chat/completions?protocol=ag-ui
+```
+
+When `protocol=ag-ui` is detected:
+1. The gateway sets `stream: true` on the upstream request (if not already).
+2. The SSE Transform emits AG-UI event envelopes instead of raw OpenAI SSE chunks.
+3. The `Content-Type` response header is `text/event-stream`.
+
+When the flag is absent, behavior is unchanged (backward compatible). This allows the Portal chat UI to opt into AG-UI while SDK/API consumers continue using raw OpenAI-compatible SSE.
+
+### 3.4 MCP Tool-Call Round-Trips as AG-UI Tool Events
+
+Arachne's existing MCP round-trip flow (`handleMcpRoundTrip()` in `src/index.ts`) already detects tool calls in provider responses and executes them against MCP endpoints. AG-UI surfaces this to the frontend:
+
+```
+1. Provider returns tool_call in response
+2. Gateway emits: ToolCallStart { toolCallId, toolCallName }
+3. Gateway emits: ToolCallArgs { delta: JSON.stringify(arguments) }
+4. Gateway emits: ToolCallEnd { toolCallId }
+5. Gateway executes MCP round-trip → gets result
+6. Gateway emits: ToolCallResult { toolCallId, content: result }
+7. Gateway re-sends to provider with tool result
+8. Provider responds with assistant message
+9. Gateway emits: TextMessageStart/Content/End for final response
+```
+
+For **streaming** MCP tool calls, argument chunks map 1:1 to `ToolCallArgs` deltas. The tool result is emitted after the MCP endpoint responds.
+
+### 3.5 AgentTeam Execution as AG-UI Steps
+
+When the request routes to `TeamOrchestrator`, each sub-agent invocation maps to AG-UI step events:
+
+| Team Event | AG-UI Events |
+|---|---|
+| Team execution begins | `RunStarted` |
+| Router agent classifies | `StepStarted { stepName: "router:triage-agent" }` → `StepFinished` |
+| Specialist agent processes | `StepStarted { stepName: "specialist:billing-agent" }` |
+| Specialist streams response | `TextMessageStart/Content/End` (within step) |
+| Specialist completes | `StepFinished { stepName: "specialist:billing-agent" }` |
+| Team execution ends | `RunFinished` |
+
+For **supervisor** pattern teams, each iteration maps to a numbered step:
+
+```
+StepStarted { stepName: "supervisor:iteration-1" }
+  ToolCallStart { toolCallName: "invoke_worker-a" }
+  ToolCallResult { content: worker-a result }
+StepFinished { stepName: "supervisor:iteration-1" }
+StepStarted { stepName: "supervisor:iteration-2" }
+  ...
+```
+
+For **parallel** pattern teams, worker steps overlap temporally (the frontend renders them concurrently).
+
+### 3.6 Trace Recording of AG-UI Events
+
+The existing `TraceRecorder` captures the full provider request/response. AG-UI events are a **derived view** of the same data, not a separate data stream. The trace already contains everything needed to reconstruct AG-UI events.
+
+However, for debugging and replay purposes, the trace can optionally record the AG-UI event sequence:
+
+```typescript
+// In the AG-UI transform, accumulate events alongside content
+interface AGUITraceExtension {
+  agui_events: BaseEvent[];   // Ordered list of emitted AG-UI events
+  agui_protocol_version: string;
+}
+```
+
+This is stored in the trace's encrypted `response_body` as an additional field. The dashboard can then replay the AG-UI event stream for debugging.
+
+### 3.7 Tenant-Automatic Compatibility
+
+Because AG-UI is a gateway-level transform:
+
+- **No agent spec changes** -- existing agents work as-is.
+- **No provider adapter changes** -- the transform sits after the provider response.
+- **No tenant configuration** -- every tenant gets AG-UI support automatically.
+- **Opt-in per request** -- clients choose AG-UI format via header/parameter.
+
+This preserves the "AI Runtime overhead < 20ms" principle: AG-UI event wrapping is pure JSON serialization with negligible overhead (the content is already being parsed for trace recording).
+
+---
+
+## 4. Portal Chat UI Integration
+
+### 4.1 Current State
+
+The Portal chat interface is a React island within the Astro + Vite Portal app. It currently:
+- Sends `POST /v1/chat/completions` with `stream: true`
+- Consumes raw OpenAI-compatible SSE chunks
+- Renders streaming text as it arrives
+- Displays conversation history from the conversation API
+
+### 4.2 AG-UI Consumer: `@ag-ui/client` vs CopilotKit React
+
+**Option A: CopilotKit React (`@copilotkit/react-core`, `@copilotkit/react-ui`)**
+
+| Pro | Con |
+|-----|-----|
+| Full-featured chat UI components | Heavy dependency (~200KB+) |
+| Built-in HITL components | Opinionated styling, hard to match Portal design system |
+| State sync hooks out of the box | Tight coupling to CopilotKit cloud features |
+| Active community | Abstractions may conflict with Arachne's auth/conversation model |
+
+**Option B: `@ag-ui/client` (lightweight SDK) + custom React hooks**
+
+| Pro | Con |
+|-----|-----|
+| ~15KB, protocol-only, no UI opinions | Must build HITL components ourselves |
+| `HttpAgent` class handles SSE connection + event parsing | More initial development work |
+| Full control over rendering and state management | No community components to reuse |
+| Clean integration with existing Portal React architecture | — |
+| MIT license, no cloud dependency | — |
+
+**Recommendation: Option B (`@ag-ui/client` + custom hooks).** The Portal already has a chat UI with its own design system. CopilotKit's React components would conflict with existing styling and auth patterns. The `@ag-ui/client` SDK provides the event parsing and SSE connection management we need, and we build the rendering layer ourselves -- which we already have.
+
+### 4.3 React Hook Architecture
+
+```typescript
+// portal/src/hooks/useAGUIChat.ts
+
+import { HttpAgent, type BaseEvent, EventType } from '@ag-ui/client';
+
+interface UseAGUIChatOptions {
+  apiKey: string;
+  agentEndpoint: string;   // /v1/chat/completions?protocol=ag-ui
+  conversationId?: string;
+}
+
+interface AGUIChatState {
+  messages: ChatMessage[];
+  isStreaming: boolean;
+  currentRun: { runId: string; threadId: string } | null;
+  activeSteps: string[];        // For AgentTeam sub-agent progress
+  activeToolCalls: ToolCallState[];
+  pendingApprovals: HITLApproval[];
+  sharedState: Record<string, unknown>;
+  error: string | null;
+}
+
+function useAGUIChat(options: UseAGUIChatOptions): AGUIChatState & {
+  sendMessage: (content: string) => Promise<void>;
+  approveToolCall: (toolCallId: string) => void;
+  rejectToolCall: (toolCallId: string, reason?: string) => void;
+  cancelRun: () => void;
+} {
+  // Implementation uses @ag-ui/client HttpAgent to connect
+  // and dispatches events to a useReducer for state management
+}
+```
+
+### 4.4 Event-to-UI Mapping
+
+| AG-UI Event | Portal UI Rendering |
+|---|---|
+| `RunStarted` | Show typing indicator, set `isStreaming = true` |
+| `TextMessageContent` | Append delta to current message bubble, render markdown incrementally |
+| `TextMessageEnd` | Finalize message bubble, clear typing indicator |
+| `ToolCallStart` | Show tool invocation chip: "Calling {toolCallName}..." |
+| `ToolCallArgs` | Expand chip to show streamed arguments (collapsible) |
+| `ToolCallResult` | Replace chip content with tool output (formatted) |
+| `StepStarted` | Show sub-agent progress indicator: "Step: {stepName}" |
+| `StepFinished` | Mark step complete (checkmark) |
+| `StateSnapshot` / `StateDelta` | Update shared state store (used by workflow editor integration) |
+| `RunError` | Display error banner with retry option |
+| `RunFinished` | Set `isStreaming = false`, enable input |
+| `ReasoningMessageContent` | Show collapsible "Thinking..." section with reasoning text |
+| `ActivitySnapshot` | Show structured activity card (plan steps, search results, etc.) |
+
+### 4.5 HITL Approval Flows
+
+AG-UI enables HITL by having the agent invoke a frontend-defined tool (e.g., `confirmAction`). The Portal chat UI implements this as:
+
+1. **Define HITL tools** in the `RunAgentInput.tools[]` array sent with each request:
+
+```typescript
+const hitlTools = [
+  {
+    name: 'confirmAction',
+    description: 'Request human approval before executing an action',
+    parameters: {
+      type: 'object',
+      properties: {
+        action: { type: 'string', description: 'Action description' },
+        details: { type: 'object', description: 'Action parameters' },
+        severity: { enum: ['info', 'warning', 'critical'] },
+      },
+      required: ['action', 'details'],
+    },
+  },
+];
+```
+
+2. **Render approval UI** when `ToolCallStart { toolCallName: "confirmAction" }` arrives:
+
+```
+┌─────────────────────────────────────────────┐
+│ 🔒 Agent requests approval                  │
+│                                              │
+│ Action: Delete customer record #4521         │
+│ Severity: ⚠️ warning                         │
+│                                              │
+│ Details:                                     │
+│   customer_id: 4521                          │
+│   reason: "duplicate account"                │
+│                                              │
+│         [ Approve ]    [ Reject ]            │
+└─────────────────────────────────────────────┘
+```
+
+3. **Return approval result** as a tool message in the next request to the agent:
+
+```typescript
+// User clicks Approve
+await sendToolResult(toolCallId, JSON.stringify({ approved: true }));
+
+// User clicks Reject
+await sendToolResult(toolCallId, JSON.stringify({
+  approved: false,
+  reason: 'Customer record is active, not a duplicate',
+}));
+```
+
+4. **Agent continues** based on the approval result.
+
+**Integration with workflow editor HITL nodes:** The workflow editor spec defines HITL approval nodes in visual workflows. When a workflow reaches a HITL node, the runtime emits `ToolCallStart { toolCallName: "confirmAction" }` with the node's configured approval parameters. The Portal chat UI renders the approval UI. This unifies the chat-based HITL and workflow-based HITL into a single AG-UI mechanism.
+
+### 4.6 Shared State Sync
+
+AG-UI shared state enables the agent to push structured data to the frontend beyond the chat stream. Use cases in the Portal:
+
+| Use Case | State Shape | AG-UI Mechanism |
+|---|---|---|
+| Workflow progress | `{ nodes: [...], edges: [...], activeNodeId }` | `StateSnapshot` on start, `StateDelta` as nodes complete |
+| Form pre-fill | `{ formFields: { name, email, ... } }` | `StateDelta` patches as agent extracts data from conversation |
+| Agent configuration | `{ model, temperature, tools[] }` | `StateSnapshot` reflecting current agent config |
+| Team execution graph | `{ agents: [...], activeAgent, delegationChain }` | `StateDelta` as sub-agents activate/complete |
+
+The Portal stores shared state in a React context and exposes it to both the chat component and the workflow editor canvas (when viewing a workflow execution).
+
+### 4.7 Sub-Agent Delegation Display
+
+For AgentTeam executions, the Portal chat UI renders a delegation tree:
+
+```
+┌─────────────────────────────────────────────┐
+│ 🤖 customer-support-team                    │
+│                                              │
+│ ├── ✅ triage-agent (routing)               │
+│ │   Classification: billing                  │
+│ │                                            │
+│ └── ⏳ billing-agent (processing...)         │
+│     │ Looking up invoice #1234...            │
+│     │ ▊▊▊▊▊▊░░░░ streaming                 │
+└─────────────────────────────────────────────┘
+```
+
+This is driven by `StepStarted`/`StepFinished` events with `stepName` encoding the agent role (e.g., `"router:triage-agent"`, `"specialist:billing-agent"`).
+
+---
+
+## 5. ACP vs A2A Analysis
+
+### 5.1 Protocol Comparison
+
+| Dimension | ACP (Arachne) | A2A (Google) |
+|---|---|---|
+| **Scope** | Internal agent-to-agent within a single Arachne runtime | Cross-platform agent-to-agent across organizational boundaries |
+| **Transport** | Raw JSON over internal function calls or message bus | JSON-RPC 2.0 over HTTP(S) + SSE |
+| **Discovery** | Semantic map handshake per session | Agent Cards (standardized capability advertisements) |
+| **Message format** | Token-minimized compressed envelopes (30-80 tokens) | Standard JSON-RPC (verbose, self-describing) |
+| **Session model** | Stateful (handshake → exchange → close) | Task-based (create → update → complete) |
+| **Budget governance** | Native (token/cost/TTL budgets propagate) | Not built-in |
+| **Traceability** | Native (correlation ID + message DAG) | Task-based (task ID tracks lifecycle) |
+| **Streaming** | Intent codes 9/10/11 (stream.start/chunk/end) | SSE for long-running tasks |
+| **Adoption** | Arachne-only (internal) | Google, multiple framework integrations |
+| **Maturity** | v0.1 spec, not yet implemented | v0.1, reference implementations available |
+
+### 5.2 Where Each Protocol Excels
+
+**ACP excels at:**
+- **High-throughput internal workflows.** 67% token savings vs MCP/JSON-RPC at 12+ messages per session. For Arachne's 50-200 message workflows, this is material.
+- **Budget-aware orchestration.** Token and cost budgets are in the protocol, not bolted on. No equivalent in A2A.
+- **Compact tracing.** Wire format = trace format. No transformation needed.
+- **Low-latency internal calls.** No HTTP overhead, no JSON-RPC framing for intra-process communication.
+
+**A2A excels at:**
+- **Cross-platform interop.** Agent Cards provide a standard discovery mechanism. An Arachne agent could advertise its capabilities to non-Arachne agents.
+- **Enterprise federation.** Designed for agents from different organizations/vendors to collaborate.
+- **Ecosystem momentum.** Google backing, growing framework support (LangGraph, CrewAI, etc.).
+- **Opacity model.** Agents collaborate without exposing internals -- important for marketplace scenarios.
+
+### 5.3 Recommendation: Hybrid Approach
+
+**Keep ACP for internal agent-to-agent communication.** ACP's token efficiency and budget governance are core differentiators for Arachne. Replacing ACP with A2A for internal communication would increase costs and latency with no benefit (internal agents don't need cross-platform interop or opacity).
+
+**Add an A2A gateway adapter for external federation.** When Arachne agents need to communicate with non-Arachne agents (marketplace, enterprise integrations), expose an A2A-compatible endpoint that translates between ACP and A2A at the boundary.
+
+```
+┌──────────────────────────────────────────────────────┐
+│ Arachne Runtime (ACP internally)                      │
+│                                                        │
+│  Agent A ←─ACP─→ Agent B ←─ACP─→ Agent C             │
+│                      │                                 │
+│                      │ A2A Gateway Adapter             │
+│                      ▼                                 │
+│              POST /a2a/tasks (JSON-RPC 2.0)           │
+└──────────────────────────────────────────────────────┘
+                       │
+                       ▼
+        ┌──────────────────────────┐
+        │ External Agent (A2A)     │
+        │ (LangGraph, CrewAI, etc) │
+        └──────────────────────────┘
+```
+
+**Implementation phases:**
+
+| Phase | Scope | Timeline |
+|---|---|---|
+| **Phase 1** (MVP) | ACP for internal teams. No A2A. | Current sprint |
+| **Phase 2** | A2A Agent Card generation from agent specs. Read-only discovery endpoint (`GET /.well-known/agent.json`). | Post-launch |
+| **Phase 3** | A2A task execution adapter. Arachne agents can receive tasks from external A2A clients and delegate to external A2A agents. | Post-launch + 1 |
+
+### 5.4 A2A Agent Card Generation
+
+Arachne agent specs contain enough information to auto-generate A2A Agent Cards:
+
+```yaml
+# Arachne Agent spec
+apiVersion: arachne-ai.com/v0
+kind: Agent
+metadata:
+  name: billing-agent
+spec:
+  model: gpt-4.1-mini
+  systemPrompt: "You handle billing support..."
+  skills:
+    - invoice_lookup
+    - payment_processing
+```
+
+Maps to A2A Agent Card:
+
+```json
+{
+  "name": "billing-agent",
+  "description": "Handles billing-related support inquiries",
+  "url": "https://acme.arachne-ai.com/a2a",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false
+  },
+  "skills": [
+    { "id": "invoice_lookup", "name": "Invoice Lookup" },
+    { "id": "payment_processing", "name": "Payment Processing" }
+  ]
+}
+```
+
+---
+
+## 6. Migration Strategy
+
+### 6.1 Phase 1: Gateway AG-UI Transform (Week 1-2)
+
+**Files to modify:**
+
+| File | Change |
+|---|---|
+| `src/streaming.ts` | Add `AGUITransform` class that wraps SSE chunks in AG-UI events |
+| `src/index.ts` | Detect `protocol=ag-ui` header/param, activate AG-UI transform |
+| `src/types.ts` | Add AG-UI event type definitions (or import from `@ag-ui/client`) |
+
+**No changes to:** auth, providers, agents, traces, database.
+
+**Testing:** Validate that an `@ag-ui/client` `HttpAgent` can connect to `POST /v1/chat/completions?protocol=ag-ui` and receive properly typed events.
+
+### 6.2 Phase 2: Portal Chat UI Migration (Week 2-3)
+
+**Dependencies to add:**
+
+```bash
+cd portal && npm install @ag-ui/client
+```
+
+**Files to create/modify:**
+
+| File | Change |
+|---|---|
+| `portal/src/hooks/useAGUIChat.ts` | New hook: AG-UI event consumer via `HttpAgent` |
+| `portal/src/components/Chat/ChatStream.tsx` | Replace raw SSE parsing with `useAGUIChat` hook |
+| `portal/src/components/Chat/ToolCallChip.tsx` | New: render tool invocations |
+| `portal/src/components/Chat/StepIndicator.tsx` | New: render AgentTeam sub-agent steps |
+| `portal/src/components/Chat/HITLApproval.tsx` | New: render approval requests |
+| `portal/src/components/Chat/ReasoningBlock.tsx` | New: collapsible thinking display |
+
+**Backward compatibility:** The existing raw SSE consumer remains as a fallback. The Portal detects AG-UI support and switches protocols automatically.
+
+### 6.3 Phase 3: MCP Tool Events + HITL (Week 3-4)
+
+Wire MCP round-trip events through the AG-UI transform. Implement frontend-defined tools for HITL approval flows. Connect to workflow editor HITL nodes.
+
+### 6.4 Phase 4: AgentTeam Step Events (Week 4-5)
+
+Modify `TeamOrchestrator` to emit AG-UI step events during sub-agent invocations. Requires the orchestrator to have access to the AG-UI event emitter (passed through `TeamContext`).
+
+---
+
+## 7. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| AG-UI spec is still evolving (pre-1.0) | Breaking changes in event schema | Pin `@ag-ui/client` version. AG-UI events are a thin wrapper; our gateway transform can adapt to schema changes without touching agent code. |
+| CopilotKit governance risk (single-company OSS) | Protocol direction could shift | AG-UI is MIT licensed. Worst case: fork the protocol types. The event schema is simple enough (~28 types) to maintain independently. Google/Microsoft adoption reduces single-vendor risk. |
+| Performance overhead of AG-UI wrapping | Gateway latency increase | AG-UI wrapping is JSON serialization of data already parsed for trace recording. Measured overhead: < 1ms per chunk. Well within the 20ms budget. |
+| HITL approval UX complexity | Poor user experience for approval flows | Start with a simple approve/reject modal. Iterate based on user feedback. The AG-UI tool-call pattern is flexible enough to support rich approval UIs later. |
+| Shared state conflicts (agent + frontend both writing) | Data corruption | Implement optimistic locking with sequence numbers. Frontend requests `StateSnapshot` on conflict detection (per AG-UI spec). |
+
+---
+
+## 8. Decisions & Open Questions
+
+### Decisions Made
+
+1. **AG-UI at the gateway level.** Events are emitted by the SSE Transform, not by individual agents. Tenants get AG-UI automatically.
+2. **`@ag-ui/client` over CopilotKit React.** Lightweight SDK + custom hooks preserves Portal design system control.
+3. **Hybrid ACP + A2A.** Keep ACP for internal agent communication; add A2A adapter for external federation in a future phase.
+4. **Opt-in per request.** AG-UI protocol is activated by `Accept` header or query parameter, preserving backward compatibility.
+
+### Open Questions
+
+1. **WebSocket for state sync?** AG-UI supports WebSocket for bi-directional state. Should the Portal use WebSocket alongside SSE, or is SSE + separate REST calls sufficient for state updates?
+2. **AG-UI event recording granularity.** Should the trace store record individual AG-UI events (higher storage cost) or just the fact that AG-UI was used (lower cost)?
+3. **Frontend tool sandboxing.** AG-UI frontend tools execute in the browser. What security boundaries do we need for tenant-defined frontend tools?
+4. **AG-UI for non-chat interfaces.** Should the Dashboard and Admin UI also consume AG-UI events (e.g., for live trace visualization)?
+5. **Versioning strategy.** When AG-UI reaches 1.0, how do we handle the transition? Support both old and new event schemas via content negotiation?
+
+---
+
+*This is a living document. Update as AG-UI evolves and implementation progresses.*

--- a/docs/system_specs/arachne_v2_tool_transport_spec.md
+++ b/docs/system_specs/arachne_v2_tool_transport_spec.md
@@ -1,0 +1,258 @@
+# Arachne v2 — Tool Transport Specification
+
+**Version:** 0.1
+**Date:** 2026-04-13
+**Status:** Draft
+**Supersedes:** `agent_tools.md` (sandboxing approach), `arachne_tool_package_spec.md` (runtime section)
+
+---
+
+## 1. Summary
+
+Arachne v2 tools use three transport models depending on where the tool runs:
+
+| Transport | When to use | Examples |
+|-----------|-------------|---------|
+| **stdio** | Local tools on the user's machine | file editor, shell, search, memory |
+| **HTTP (StreamableHttp)** | Remote tools on the network | calendar API, email, web fetch |
+| **Platform** | In-process utilities with no serialization overhead | token counting, schema validation |
+
+This replaces the Arachne v1 approach (HTTP-only MCP calls) and the specced-but-unbuilt Azure Container Apps Dynamic Sessions sandbox.
+
+All three transports speak the **MCP protocol** at the application layer. Transport is an infrastructure concern; the agent sees the same `tools/call` interface regardless.
+
+---
+
+## 2. Transport Details
+
+### 2.1 stdio (Local Tools)
+
+The Arachne runtime spawns a subprocess for each tool server. Communication is via stdin/stdout using JSON-RPC 2.0. No ports, no auth headers, no service discovery.
+
+```
+Arachne runtime process
+  └── spawns: arachne-tool-file-editor
+        stdin  ← {"jsonrpc":"2.0","method":"tools/call","params":{"name":"read_file","arguments":{"path":"..."}}}
+        stdout → {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"..."}]}}
+```
+
+**Subprocess lifecycle:** tied to the workspace session. When the session ends, the subprocess is terminated. No daemon processes.
+
+**Security model (current):** subprocess isolation only — the tool process runs as the same user. Equivalent to the user running the command themselves.
+
+**Security model (roadmap):** WASM sandbox (see Section 4).
+
+**Use for:** any tool that operates on local resources — file system, local databases, shell commands, local memory search.
+
+---
+
+### 2.2 HTTP / StreamableHttp (Remote Tools)
+
+Standard HTTP transport: `POST` to a URL with a JSON-RPC 2.0 body. The tool server is a network service. Response may be streamed (SSE) or returned as a single JSON response.
+
+```
+Arachne runtime
+  └── POST https://tools.example.com/mcp
+        Body: {"jsonrpc":"2.0","method":"tools/call","params":{...}}
+        Response: {"jsonrpc":"2.0","result":{...}}
+```
+
+**Auth:** Bearer token in `Authorization` header, resolved from the agent's credential store per principal.
+
+**Use for:** tools that are inherently remote — calendar (M365/Google), email, Slack, external web APIs, payment processors. Also correct for cloud-hosted tool packages where the tool server is a managed microservice.
+
+---
+
+### 2.3 Platform (In-Process)
+
+Direct function call within the Arachne runtime process. No subprocess, no network, no JSON serialization. Implements the same `McpClientTrait` interface as the other transports so the agent dispatch layer treats them identically.
+
+```rust
+// Platform tool — zero overhead
+impl McpClientTrait for TokenCounterTool {
+    async fn call_tool(&self, ctx: &ToolCallContext, name: &str, args: Option<JsonObject>, _: CancellationToken) -> Result<CallToolResult> {
+        match name {
+            "count_tokens" => self.count(args),
+            _ => Err(Error::ToolNotFound(name.into())),
+        }
+    }
+}
+```
+
+**Use for:** utilities where network/subprocess overhead is unacceptable — token counting, schema validation, format conversion, memory index queries.
+
+---
+
+## 3. Tool Package Format
+
+`.tool.orb` is the portable artifact format. A package is a gzip-compressed tar with a `manifest.json` at root.
+
+```
+my-tool-package-1.0.0.tool.orb
+├── manifest.json
+├── dist/
+│   └── server.js      ← bundled MCP stdio server (Node.js or Deno)
+└── assets/            ← optional static files
+```
+
+**Manifest:**
+
+```json
+{
+  "kind": "arachne.tool-package",
+  "schema_version": "2.0",
+  "package": {
+    "id": "acme.web-tools",
+    "version": "1.0.0",
+    "runtime": "node",
+    "entrypoint": "./dist/server.js"
+  },
+  "transport": "stdio",
+  "tools": [
+    {
+      "id": "web.read",
+      "name": "Read Web Page",
+      "description": "Fetches and sanitizes webpage content.",
+      "handler": "webRead",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "url": { "type": "string", "format": "uri" }
+        },
+        "required": ["url"]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "content": { "type": "string" }
+        }
+      },
+      "annotations": {
+        "read_only_hint": true
+      },
+      "permissions": {
+        "network": ["fetch"]
+      }
+    }
+  ]
+}
+```
+
+The `entrypoint` is a stdio MCP server. Arachne spawns it as a subprocess and communicates via stdin/stdout. This is the same pattern Goose uses for builtin extensions — it works with any language that can read stdin and write stdout.
+
+---
+
+## 4. WASM Sandbox (Roadmap)
+
+The stdio subprocess model gives process isolation but no capability restrictions — the tool process inherits the user's permissions. WASM is the upgrade path.
+
+**Target:** `.tool.orb` packages can contain a `.wasm` component (WASI preview 2) instead of a JS bundle. The Arachne runtime executes it via Wasmtime with explicit capability grants.
+
+```json
+{
+  "package": {
+    "runtime": "wasm",
+    "entrypoint": "./dist/tool.wasm"
+  },
+  "permissions": {
+    "fs": [{ "path": "{workspace_dir}", "mode": "read-write" }],
+    "network": ["fetch"],
+    "env": []
+  }
+}
+```
+
+**Capability grants (WASI):**
+
+| Permission key | What it grants |
+|----------------|----------------|
+| `fs.path` | Access to specific directories only |
+| `network.fetch` | Outbound HTTP only |
+| `network.listen` | Inbound socket (rarely needed) |
+| `env` | Specific environment variables |
+
+No grant = no access. A file editor with `fs: [{path: "{workspace_dir}"}]` cannot read `/etc/passwd`. A web fetcher with `network: ["fetch"]` cannot open a socket listener.
+
+**Migration path:** `runtime: "node"` → stdio subprocess (current). `runtime: "wasm"` → Wasmtime sandbox (roadmap). Same manifest format, same MCP protocol, same `.tool.orb` container. Tools can ship both — runtime negotiation at install time.
+
+---
+
+## 5. Permission & Inspection Pipeline
+
+Inherited from the Goose model, adapted for Arachne's multi-tenant context.
+
+Every tool call passes through the inspection pipeline before dispatch:
+
+```
+Tool call request
+  → PermissionInspector     (AlwaysAllow / AskBefore / NeverAllow per tool, per user)
+  → AdversaryInspector      (prompt injection detection)
+  → EgressInspector         (data exfiltration prevention)
+  → SecurityInspector       (dangerous command detection)
+  → RepetitionInspector     (tool call loop detection)
+
+Result: approved | needs_approval | denied
+
+  approved        → dispatch immediately
+  needs_approval  → yield ActionRequired to UI, await confirmation
+  denied          → return DECLINED_RESPONSE to agent
+```
+
+**Confirmation types (user can choose):**
+- `AlwaysAllow` — remember globally for this tool
+- `AllowOnce` — this call only
+- `DenyOnce` — this call only
+- `AlwaysDeny` — remember globally for this tool
+
+**Tool annotations that affect inspection:**
+- `read_only_hint: true` — PermissionInspector auto-approves without asking user
+- `annotations.destructive: true` — SecurityInspector escalates to `needs_approval` regardless of saved preference
+
+---
+
+## 6. Extension Config (Arachne v2 Agent YAML)
+
+```yaml
+tools:
+  - type: stdio
+    package: arachne.developer@1.0.0     # resolves from local registry
+    available_tools: []                  # empty = all tools
+
+  - type: stdio
+    package: acme.web-tools@2.1.0
+
+  - type: http
+    name: google-calendar
+    uri: https://calendar-mcp.synapticweave.com
+    auth:
+      type: bearer
+      credential: principal://google_oauth  # per-principal OAuth token
+
+  - type: platform
+    name: token-counter                   # built-in, zero config
+```
+
+---
+
+## 7. Arachne v1 → v2 Migration
+
+| v1 Behavior | v2 Behavior |
+|-------------|-------------|
+| Skills injected as OpenAI `tools` array | Same — tool format is still OpenAI-compatible at the LLM boundary |
+| MCP endpoints: HTTP only | stdio (local), HTTP (remote), platform (in-process) |
+| One round-trip max | Full agentic loop (N turns until done) |
+| No permission system | 5-inspector pipeline, user confirmation flow |
+| Azure Container Apps sandbox (specced) | stdio subprocess → WASM component (roadmap) |
+| No built-in tools | Developer, memory, and core tools ship with the runtime |
+
+---
+
+## 8. Open Questions
+
+1. **Credential store:** Per-principal OAuth tokens for HTTP tools — where do they live? Encrypted in local SQLite for Forge/Flow; in Arachne Cloud for remote deployments.
+
+2. **WASM toolchain:** Wasmtime (Rust) is the natural fit given the Rust runtime. Confirm compatibility with the `goose-sdk` tool dispatch layer before committing.
+
+3. **Large result handling:** Goose summarizes tool results > 50KB before feeding back to the LLM. Threshold and summarization model need to be configurable per agent.
+
+4. **Cross-platform stdio:** Windows stdin/stdout behavior differs from Unix. Need to validate subprocess lifecycle management on Windows (relevant for Flow on Windows).

--- a/docs/system_specs/beta_signup_enrichment_spec.md
+++ b/docs/system_specs/beta_signup_enrichment_spec.md
@@ -1,0 +1,63 @@
+# Beta Signup Enrichment
+
+## Problem
+
+Beta signups currently capture only an email address. This provides no context for customer discovery, interview prioritization, or understanding who is signing up and why. Three beta registrants are in the pipeline with no demographic information beyond their email.
+
+## Solution
+
+Add four fields to the beta signup form. Keep it short enough that it doesn't kill conversion.
+
+## Fields
+
+| Field | Type | Required | Purpose |
+|-------|------|----------|---------|
+| Email | email | Yes | Already exists |
+| Company or Project | text (free) | Yes | Identify the organization or product |
+| Role | select | Yes | Segment by persona (founder, engineer, platform lead, other) |
+| What are you building? | text (free, one line) | No | Understand use case and pain point |
+| Agents in production? | select | No | Prioritize outreach (0 / 1-5 / 5+) |
+
+## Role Options
+
+- Founder / Co-founder
+- Engineering Lead / Manager
+- Platform / Infrastructure Engineer
+- Individual Developer
+- Other
+
+## Agents in Production Options
+
+- None yet (exploring)
+- 1-5
+- 5+
+
+## Implementation
+
+- Add fields to the existing signup form on arachne-ai.com
+- Store in the same datastore as current registrations
+- Backfill: send a short follow-up to existing registrants asking them to complete their profile (frame it as "help us prioritize your beta access")
+
+## Design Constraints
+
+- The form should remain completable in under 30 seconds
+- Required fields: email, company, role. Optional: what are you building, agents in production
+- No multi-page forms. Single view, single submit.
+
+## Backfill Email (Draft)
+
+Subject: Quick question about your Arachne beta signup
+
+Body:
+
+Hey [name or "there"],
+
+You signed up for the Arachne beta — thank you. We're rolling out access and want to make sure we prioritize the right use cases.
+
+Could you take 15 seconds to tell us a bit more?
+
+[Link to short form: company, role, what you're building, agents in production]
+
+That's it. No demo, no sales call, just context so we can get you the right access.
+
+— Michael

--- a/docs/system_specs/goose_extraction_spec.md
+++ b/docs/system_specs/goose_extraction_spec.md
@@ -1,0 +1,415 @@
+# Goose Component Extraction and Arachne Integration Specification
+
+**Date:** 2026-04-08
+**Status:** Draft (pending Neo + Morpheus review)
+**Source:** Synaptic-Weave/hephaestus (fork of aaif-goose/goose, Apache 2.0)
+**Target:** Synaptic-Weave/arachne
+
+---
+
+## 1. Context
+
+Goose is an open-source AI coding agent (39K stars, Rust, Apache 2.0) built by Block (formerly Square). It contains production-quality implementations of several capabilities that are on Arachne's roadmap but not yet built: MCP tool execution, ACP agent coordination, provider gateway with streaming/fallback, context management, and sandboxed code execution.
+
+Rather than building these from scratch in TypeScript, we extract the relevant Rust crates from Goose and integrate them as Arachne's high-performance core. The existing TypeScript API layer (Fastify) remains as the tenant-facing surface; the Rust core handles the compute-intensive agent runtime operations.
+
+This also establishes the architecture for **Forge**, a CLI/desktop coding agent client that connects to Arachne, and **Hephaestus**, the coding agent persona that runs as an Arachne agent.
+
+---
+
+## 2. Architecture
+
+### Current Arachne
+```
+Client → Fastify API (TypeScript) → LLM Provider → Response
+              ↓
+         PostgreSQL (tenants, agents, conversations, traces)
+         pgvector (knowledge base RAG)
+```
+
+### Target Arachne (with Goose extraction)
+
+Forge IS a local Arachne instance. Not a thin client connecting to one. Tools run locally, code never leaves the machine, only inference calls go out (and even those are optional with Ollama).
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ FORGE (Local Arachne Instance)                                │
+│ CLI + Electron Desktop App                                    │
+│                                                               │
+│  Rust Agent Core (extracted from Goose):                      │
+│    ├── MCP Host — LOCAL tool execution                        │
+│    │   ├── file-editor (read/write/edit files)                │
+│    │   ├── shell (execute commands)                           │
+│    │   ├── search (grep, glob, find)                          │
+│    │   └── total-recall (memory search)                       │
+│    ├── ACP — agent-to-agent coordination                      │
+│    ├── Context Manager — compression + Total Recall hooks     │
+│    └── Execution Sandbox — safe code/shell execution          │
+│                                                               │
+│  Local Storage:                                               │
+│    ├── Total Recall SQLite (offline memory cache)             │
+│    └── Agent state and conversation history                   │
+│                                                               │
+│  Agents:                                                      │
+│    ├── Hephaestus (coding agent, pre-loaded)                  │
+│    └── User-installed agents (from registry)                  │
+│                                                               │
+│  Model Routing (configurable):                                │
+│    ├── Ollama (fully local, free, zero network)               │
+│    ├── Arachne Cloud (our hosted Vertex AI / Claude Opus)     │
+│    └── Arachne Enterprise (customer's self-hosted instance)   │
+│                                                               │
+│  Sync (optional):                                             │
+│    ├── Total Recall Cloud (memory across machines)            │
+│    └── Arachne Cloud Registry (push/pull agent artifacts)     │
+└──────────────────────────────────────────────────────────────┘
+
+                    ▲ optional sync ▲
+                    │               │
+        ┌───────────┴──┐    ┌──────┴──────────────────────┐
+        │ Total Recall │    │ Arachne Cloud / Enterprise   │
+        │ Cloud        │    │                              │
+        │ Memory sync  │    │ Hosted providers (Vertex AI) │
+        │ Team memory  │    │ Agent registry               │
+        │              │    │ Team management               │
+        └──────────────┘    │ Billing, observability       │
+                            │ Multi-tenant governance      │
+                            └─────────────────────────────┘
+```
+
+### Key Principle: Code Never Leaves the Machine
+
+- **File reads/writes**: Always local. MCP tools run in Forge's local Arachne instance.
+- **Shell commands**: Always local. Execution sandbox runs on the user's machine.
+- **Search/grep**: Always local. No code sent to any server.
+- **Memory**: Local SQLite first. Cloud sync is optional and encrypted (vector rotation).
+- **Inference**: Only the conversation goes to the model provider. Even this is optional with Ollama.
+- **Fully offline capable**: Ollama + local SQLite + local tools = zero network required.
+
+### The "Docker for AI" Analogy
+
+| Docker | Arachne |
+|--------|---------|
+| Docker Desktop | Forge (local Arachne instance for developers) |
+| Docker Engine | Arachne Core (Rust runtime extracted from Goose) |
+| Container | Agent artifact (YAML spec + prompt + tools + knowledge base) |
+| Docker Hub | Arachne Cloud Registry (push/pull agents) |
+| Dockerfile | Agent definition YAML |
+| Docker Compose | Agent team orchestration (ACP) |
+| ECS / Kubernetes | Arachne Cloud / Enterprise (hosted multi-tenant runtime) |
+| Volume mounts | MCP tool connections (local file system, shell, etc.) |
+
+A developer installs Forge, gets a full local Arachne with Hephaestus pre-loaded. Their code stays local. Their agents are portable. They can push agents to Arachne Cloud or their company's Arachne Enterprise, just like pushing a Docker image to a registry.
+
+---
+
+## 3. Goose Crates to Extract
+
+### 3.1 MCP Host (`goose-mcp`)
+
+**What it provides:**
+- Full MCP client implementation (connect to MCP servers, invoke tools, handle responses)
+- MCP server implementation (expose tools to other agents)
+- Tool discovery and schema validation
+- Streaming tool results
+
+**Maps to Arachne gap:**
+- Issue #136: Tool execution spec (unimplemented)
+- Tool package format spec (`arachne_tool_package_spec.md`)
+- Currently agents have no tool execution capability beyond RAG retrieval
+
+**Integration approach:**
+- Extract `crates/goose-mcp` as a standalone Rust library
+- Expose via FFI (napi-rs) to the TypeScript layer, or run as a sidecar process
+- Each Arachne agent deployment gets an MCP host with configured tool servers
+- Tool packages defined in YAML (existing spec) map to MCP server configurations
+
+**Stories:**
+1. Extract goose-mcp crate, build as standalone library
+2. Create napi-rs bindings (or gRPC sidecar) for TypeScript integration
+3. Wire MCP host into Arachne agent execution pipeline
+4. Map Arachne tool package YAML to MCP server configs
+5. Add tool execution tracing to observability pipeline
+
+### 3.2 ACP Agent Coordination (`goose-acp`)
+
+**What it provides:**
+- Agent-to-agent communication protocol
+- Message passing between agents
+- Coordination patterns (sequential, parallel, delegation)
+- Agent discovery and capability advertisement
+
+**Maps to Arachne gap:**
+- Multi-agent orchestration (listed as "coming soon" in platform docs)
+- Agent chaining and workflow execution
+- The Matrix team pattern (multiple specialist agents coordinating) as a first-class platform feature
+
+**Integration approach:**
+- Extract `crates/goose-acp` as standalone library
+- ACP becomes the protocol for Arachne's multi-agent orchestration
+- Tenant-defined agent teams coordinate via ACP
+- Each agent is an ACP participant with declared capabilities
+
+**Stories:**
+1. Extract goose-acp crate
+2. Define Arachne agent ↔ ACP participant mapping
+3. Implement agent team orchestration via ACP (sequential, parallel, delegation)
+4. Add agent coordination tracing
+5. Expose team orchestration in portal UI (workflow designer from existing spec)
+
+### 3.3 Provider Gateway (`goose/src/gateway/`)
+
+**What it provides:**
+- Multi-provider LLM routing (OpenAI, Anthropic, Google, Ollama, Azure, etc.)
+- Streaming response handling
+- Automatic fallback chains (primary → secondary → local)
+- Token counting and cost estimation
+- Rate limiting and retry logic
+
+**Maps to Arachne gap:**
+- Arachne already has a TypeScript provider gateway, but Goose's Rust version is faster and more mature
+- Fallback chains are not implemented in Arachne
+- Streaming is handled but could be more robust
+
+**Integration approach:**
+- Don't replace the TypeScript gateway immediately
+- Extract the provider abstraction patterns and fallback chain logic
+- Port the streaming improvements back to TypeScript, or gradually migrate hot paths to Rust
+- Add Vertex AI provider (for Claude Opus via GCP credits)
+
+**Stories:**
+1. Audit Goose provider gateway vs Arachne gateway (feature comparison)
+2. Port fallback chain logic to Arachne TypeScript gateway
+3. Add Vertex AI provider to Arachne
+4. Evaluate FFI bridge for streaming performance (future)
+
+### 3.4 Context Management (`goose/src/context_mgmt/`)
+
+**What it provides:**
+- Context window tracking (token counting per message)
+- Compression decision logic (when to compress, what to keep)
+- Summary generation for compressed context
+- Hook system for pre/post compression events
+
+**Maps to Arachne gap:**
+- Arachne conversation management exists but has no intelligent compression
+- Total Recall PreCompact/PostCompact hooks need a compression system to hook into
+- Long-running agent conversations need context management
+
+**Integration approach:**
+- Extract context management patterns
+- Integrate with Total Recall: before compression, save to knowledge graph; after compression, re-inject relevant context
+- This is the core of the "agents with memory" value proposition
+
+**Stories:**
+1. Extract context management logic from Goose
+2. Define Arachne context management interface
+3. Integrate Total Recall PreCompact hook (save before compress)
+4. Integrate Total Recall PostCompact hook (re-inject after compress)
+5. Add context management configuration per agent (max tokens, compression strategy)
+
+### 3.5 Execution Sandbox (`goose/src/execution/`)
+
+**What it provides:**
+- Safe shell command execution with timeouts
+- File system read/write with permission controls
+- Code execution in sandboxed environments
+- Output capture and streaming
+
+**Maps to Arachne gap:**
+- Arachne agents currently can't execute code or modify files
+- Tool execution (MCP) needs a safe execution environment
+- Enterprise deployments need sandboxing (agents shouldn't escape their tenant boundary)
+
+**Integration approach:**
+- Extract execution primitives
+- Layer tenant isolation on top (each agent runs in its tenant's sandbox)
+- Integrate with MCP tools (file edit tool uses the sandbox, shell tool uses the sandbox)
+
+**Stories:**
+1. Extract execution sandbox from Goose
+2. Add tenant-scoped file system access (agents only see their tenant's workspace)
+3. Add tenant-scoped shell execution (resource limits, network restrictions)
+4. Integrate sandbox with MCP tool execution
+
+---
+
+## 4. Forge as Local Arachne Instance
+
+### 4.1 What Forge Is
+
+Forge is a local Arachne instance packaged as a developer tool (CLI + Electron desktop). It IS Arachne, running on the developer's machine, with Hephaestus pre-loaded as the default coding agent. Think: "Docker Desktop is Docker purpose-built for developers. Forge is Arachne purpose-built for developers."
+
+### 4.2 Forge Responsibilities
+
+- **Full local Arachne runtime** (Rust core: MCP, ACP, context management, execution sandbox)
+- **Local tool execution** (file edit, shell, search, all MCP tools run locally)
+- **Local memory** (Total Recall SQLite, offline-first, optional cloud sync)
+- **Model routing** (Ollama for local, Arachne Cloud for hosted providers, Enterprise for self-hosted)
+- **Agent management** (install agents from registry, configure tools, manage knowledge bases)
+- **Terminal UI and desktop app** (from Goose's ui/ directory, Forge-branded)
+
+### 4.3 What Forge Does NOT Do Locally
+
+- **Multi-tenancy** (that's Arachne Cloud / Enterprise)
+- **Billing** (that's Arachne Cloud)
+- **Team management** (that's Arachne Cloud / Enterprise, though team memory syncs via Total Recall)
+
+### 4.4 Forge Modes
+
+**Fully local (offline):**
+```
+Forge (local Arachne) → Hephaestus → Ollama (local inference)
+  ├── Tools: local MCP (file, shell, search)
+  ├── Memory: local SQLite only
+  └── Network: none required
+```
+
+**Local + cloud inference:**
+```
+Forge (local Arachne) → Hephaestus → Arachne Cloud → Vertex AI / Claude Opus
+  ├── Tools: local MCP (file, shell, search) — code stays local
+  ├── Memory: local SQLite + Total Recall Cloud sync
+  └── Network: only inference calls + memory sync
+```
+
+**Local + enterprise:**
+```
+Forge (local Arachne) → Hephaestus → Arachne Enterprise (company-hosted)
+  ├── Tools: local MCP — code stays local
+  ├── Memory: local SQLite + company Total Recall instance
+  ├── Agents: pulled from company's private registry
+  └── Governance: company content policies enforced
+```
+
+---
+
+## 5. Hephaestus as Arachne Agent
+
+### 5.1 What Hephaestus Is
+
+Hephaestus is a coding agent deployed on the Arachne platform. It is defined as an Arachne agent artifact (YAML spec + system prompt + tool configuration + knowledge base refs).
+
+### 5.2 Agent Definition
+
+```yaml
+name: hephaestus
+version: 1.0.0
+kind: Agent
+spec:
+  system_prompt: |
+    You are Hephaestus, an AI coding agent. You help developers write,
+    debug, and refactor code. You have access to the user's file system,
+    shell, and search tools via MCP. You remember context from prior
+    sessions via Total Recall.
+  model:
+    provider: vertex-ai
+    model: claude-opus-4-6
+    fallback:
+      - provider: anthropic
+        model: claude-opus-4-6
+      - provider: ollama
+        model: qwen2.5-coder:32b
+  tools:
+    - mcp://file-editor          # read, write, edit files
+    - mcp://shell                # execute shell commands
+    - mcp://search               # grep, glob, find
+    - mcp://browser              # web fetch, documentation lookup
+    - mcp://total-recall         # session memory search
+  knowledge_bases:
+    - total-recall://user/{user_id}/sessions    # all prior sessions
+    - total-recall://user/{user_id}/codebase    # indexed codebase
+  memory:
+    provider: total-recall
+    precompact: true             # save before compression
+    postcompact: true            # re-inject after compression
+  context:
+    max_tokens: 200000
+    compression_strategy: total-recall   # use TR instead of built-in
+```
+
+### 5.3 Hephaestus Differentiators (vs. vanilla Goose)
+
+| Feature | Goose | Hephaestus on Arachne |
+|---------|-------|-----------------------|
+| Memory | Session-only, lost on exit | Total Recall: persistent across sessions, searchable, synced across machines |
+| Deployment | Local only | Cloud, local, or hybrid via Arachne |
+| Multi-agent | Single agent | Can delegate to other Arachne agents (QA agent, DevOps agent, etc.) via ACP |
+| Observability | Basic logging | Full Arachne tracing (tokens, latency, cost per request) |
+| Governance | None | Arachne content policies, rate limits, budget caps |
+| Team memory | None | Shared team knowledge graph (with privacy-preserving vector rotation) |
+| Provider routing | Static config | Dynamic per-tenant, with fallback chains and cost optimization |
+
+---
+
+## 6. Integration Strategy
+
+### Phase 1: Forge Ships (Now)
+- Forge = Goose fork with Forge branding + Total Recall memory plugin
+- Forge IS a local Arachne instance (even if minimal at first)
+- Ships as CLI + desktop app, works with Ollama (local) or any cloud provider
+- Hephaestus pre-loaded as default coding agent
+- Validates the UX and builds user base
+- "Your code never leaves your machine"
+
+### Phase 2: Arachne Core in Rust (Next)
+- Extract MCP, ACP, provider gateway, context management from Goose
+- Formalize as `arachne-core` Rust crates (the engine that powers both Forge locally and Arachne Cloud remotely)
+- Same core runs everywhere: developer laptop, cloud instance, enterprise server
+- Agent artifacts are portable: define once, run on any Arachne instance
+
+### Phase 3: Arachne Cloud + Registry (After)
+- Arachne Cloud = hosted multi-tenant Arachne with Vertex AI providers
+- Agent registry: push/pull agent artifacts (like Docker Hub)
+- Forge connects to Arachne Cloud for: hosted inference, team memory sync, agent marketplace
+- Enterprise customers self-host Arachne with their own providers and governance
+
+### Phase 4: Platform + Ecosystem (Future)
+- Multiple clients: Forge (coding), Charlotte (voice), web IDE, VS Code extension, mobile
+- Agent marketplace: third-party agents, tool packages, knowledge base templates
+- Team features: shared memory with privacy-preserving vector rotation, audit logs, SSO
+- Arachne becomes the "Docker Hub + Kubernetes" of AI agents
+
+---
+
+## 7. Licensing
+
+All extracted Goose components retain their Apache 2.0 license. Arachne's TypeScript layer and Forge's UI customizations are proprietary to Synaptic Weave, Inc. The Rust core crates extracted from Goose are published as open-source Apache 2.0 under the Synaptic-Weave org with attribution to Block/AAIF.
+
+This satisfies Apache 2.0 requirements:
+- Original license and NOTICE file included
+- Changes documented
+- No claim of endorsement by Block
+
+---
+
+## 8. Stories (Summary)
+
+| # | Story | Phase | Team |
+|---|-------|-------|------|
+| 1 | Extract goose-mcp as standalone crate | 2 | Tank |
+| 2 | Create napi-rs bindings for MCP host | 2 | Tank |
+| 3 | Wire MCP into Arachne agent execution | 2 | Tank |
+| 4 | Extract goose-acp as standalone crate | 2 | Tank |
+| 5 | Define agent ↔ ACP participant mapping | 2 | Architect |
+| 6 | Implement multi-agent orchestration via ACP | 3 | Tank + Oracle |
+| 7 | Audit Goose vs Arachne provider gateway | 2 | Oracle |
+| 8 | Port fallback chain logic to Arachne | 2 | Tank |
+| 9 | Add Vertex AI provider to Arachne | 2 | Tank + Oracle |
+| 10 | Extract context management from Goose | 2 | Tank |
+| 11 | Integrate Total Recall Pre/PostCompact | 2 | Oracle |
+| 12 | Extract execution sandbox from Goose | 2 | Tank |
+| 13 | Add tenant-scoped sandbox isolation | 3 | Tank + Niobe |
+| 14 | Define Hephaestus agent YAML artifact | 3 | Architect + Neo |
+| 15 | Forge standalone mode (Goose + TR plugin) | 1 | Switch + Tank |
+| 16 | Forge → Arachne connection mode | 3 | Switch + Tank |
+| 17 | Forge branding and UX customization | 1 | Trinity + Switch |
+
+---
+
+## 9. Open Questions
+
+1. **FFI vs sidecar**: Should the Rust core be called via napi-rs FFI (faster, tighter integration) or as a gRPC sidecar process (simpler deployment, language-agnostic)? Tank to evaluate.
+2. **Goose upstream contributions**: Should we contribute Arachne-specific improvements back to Goose? Good for community, but exposes our roadmap.
+3. **Standalone mode longevity**: How long does Forge standalone mode (Phase 1) last before we require Arachne? Need to balance user adoption vs platform lock-in.
+4. **Agent marketplace timeline**: When do we open Arachne to third-party agents? Phase 4, but need to plan the artifact format now.

--- a/docs/system_specs/oas_arachne_mapping.md
+++ b/docs/system_specs/oas_arachne_mapping.md
@@ -1,0 +1,461 @@
+# Open Agent Spec (OAS) ↔ Arachne — Concept Mapping & Gap Analysis
+
+**Author:** Oracle (AI Systems Advisor)
+**Date:** April 1, 2026
+**Status:** Draft
+
+---
+
+## 1. Executive Summary
+
+The [Open Agent Spec](https://github.com/oracle/agent-spec) (OAS, also known as PyAgentSpec) is Oracle's portable, platform-agnostic configuration language for describing AI agents and workflows. [WayFlow](https://oracle.github.io/wayflow/26.1.1/) is Oracle's reference runtime that executes OAS definitions. OAS emphasizes **portability across frameworks** (LangGraph, AutoGen, CrewAI adapters) and **declarative agent definition** (YAML/JSON serialization).
+
+Arachne is Synaptic Weave's **AI runtime and deployment platform** with a full artifact lifecycle (weave → push → deploy), multi-tenant isolation, encrypted observability, conversation memory, and a proprietary communication protocol (ACP). Arachne uses YAML spec files with `apiVersion`/`kind`/`metadata`/`spec` structure, inspired by Kubernetes resource manifests.
+
+**Key Finding:** The two systems share the same fundamental concepts (agents, tools, multi-agent coordination, LLM abstraction) but differ significantly in scope and emphasis. OAS is a **specification and serialization format** with runtime adapters; Arachne is a **full deployment runtime** with multi-tenancy, encryption, and operational infrastructure. A compatibility layer is feasible, and Arachne could become an OAS-compatible runtime while retaining its differentiating features.
+
+---
+
+## 2. Side-by-Side Concept Table
+
+| # | OAS Concept | OAS Module | Arachne Equivalent | Arachne Spec/Module | Notes |
+|---|-------------|------------|---------------------|---------------------|-------|
+| 1 | **Component** (base class) | `component.py` — `id`, `name`, `description`, `metadata`, `component_type` | **Artifact** — `apiVersion`, `kind`, `metadata.name`, `spec` | Workspace spec, all artifact kinds | OAS uses Pydantic models with auto-generated `id`; Arachne uses K8s-style manifests. Both are YAML-serializable. |
+| 2 | **Agent** | `agent.py` — `system_prompt`, `llm_config`, `tools`, `toolboxes`, `human_in_the_loop`, `transforms` | **Agent** (`kind: Agent`) | `agent_team_spec.md`, `architecture.md` | Near 1:1 mapping. OAS Agent has `transforms` (message middleware); Arachne has `knowledgeBaseRef`, `channels`, `schedule`. |
+| 3 | **LlmConfig** | `llms/llmconfig.py` — abstract, with `OciGenAiConfig`, `OpenAiConfig`, `OllamaConfig`, `GeminiConfig`, `VllmConfig`, `OpenAiCompatibleConfig` | **Provider Config** (`provider_config` JSONB on Tenant entity) + **BaseProvider** adapter pattern | `architecture.md` §9 | OAS binds LLM config per-agent; Arachne inherits provider config per-tenant with agent-level model override. Arachne's provider registry is a runtime adapter layer comparable to OAS's framework adapters. |
+| 4 | **LlmGenerationConfig** | `llms/llmgenerationconfig.py` — temperature, top_p, max_tokens, stop sequences | **Request body parameters** | Passed through in chat completion request | OAS makes generation params a first-class config object; Arachne passes them through the OpenAI-compatible API surface. |
+| 5 | **Tool** (abstract) | `tools/tool.py` — `requires_confirmation`, inherits `ComponentWithIO` (inputs/outputs) | **Tool** (within `ToolPackage`) | `agent_tools.md` | Both define tools with name, description, input/output schemas. |
+| 6 | **ServerTool** | `tools/servertool.py` — "executed by the orchestrator" | **ToolPackage handler** (server-side execution in sandbox) | `agent_tools.md` §Step 6 | Arachne executes tool handlers in Azure Container Apps Dynamic Sessions; OAS delegates to the runtime adapter. |
+| 7 | **ClientTool** | `tools/clienttool.py` — "run by the client application" | **MCP tool** (client-side execution via MCP round-trip) | `architecture.md` §3.1 | Arachne's MCP round-trip pattern maps to OAS's ClientTool concept — the client application provides the tool result. |
+| 8 | **RemoteTool** | `tools/remotetool.py` — remote endpoint tool | **Webhook tool / MCP endpoint** | `agent_tools.md` | Both support calling external endpoints as tool execution. |
+| 9 | **ToolBox** | `tools/toolbox.py` — collection of related tools | **ToolPackage** (`kind: ToolPackage`) | `agent_tools.md` §Tool Package | 1:1 mapping. Both group related tools into a versioned, distributable unit. |
+| 10 | **Flow** | `flows/flow.py` — DAG of nodes with control-flow and data-flow edges | **No direct equivalent** | — | **Gap in Arachne.** OAS Flows are structured DAG workflows with typed nodes (LLM, Tool, API, Branching, Parallel, Map). Arachne's AgentTeam coordination patterns (routing, handoff, parallel, supervisor) cover a subset of flow patterns but are not general-purpose DAGs. |
+| 11 | **Flow Nodes** — `StartNode`, `EndNode`, `AgentNode`, `LlmNode`, `ToolNode`, `ApiNode`, `BranchingNode`, `MapNode`, `ParallelFlowNode`, `ParallelMapNode`, `CatchExceptionNode`, `InputMessageNode`, `OutputMessageNode`, `FlowNode` (sub-flow) | `flows/nodes/` | **Coordination patterns** (routing, handoff, parallel, supervisor) | `agent_team_spec.md` | Arachne has 4 fixed patterns; OAS has 14+ composable node types. OAS is significantly richer here. |
+| 12 | **Control-Flow Edge** | `flows/edges/controlflowedge.py` — transitions between nodes | **Coordination pattern logic** (implicit in pattern) | `agent_team_spec.md` | Arachne's edges are implicit in the pattern definition; OAS edges are explicit, user-defined. |
+| 13 | **Data-Flow Edge** | `flows/edges/dataflowedge.py` — property mappings between node I/O | **No equivalent** | — | **Gap in Arachne.** Arachne passes outputs between pipeline stages as message content, not as typed property mappings. |
+| 14 | **Swarm** | `swarm.py` — multi-agent with `relationships`, `first_agent`, `HandoffMode` (NEVER/OPTIONAL/ALWAYS) | **AgentTeam** with `coordination: routing` or `coordination: supervisor` | `agent_team_spec.md` | Partial mapping. OAS Swarm defines pairwise agent relationships and handoff modes; Arachne uses declarative patterns. Arachne's routing pattern maps to Swarm with directed relationships; supervisor maps to Swarm with OPTIONAL handoff. |
+| 15 | **ManagerWorkers** | `managerworkers.py` — `group_manager` + `workers[]` | **AgentTeam** with `coordination: supervisor` | `agent_team_spec.md` §Supervisor | Strong mapping. OAS `group_manager` → Arachne `spec.supervisor.agent`; OAS `workers[]` → Arachne `spec.supervisor.workers[]`. Arachne adds `maxIterations` safety limit. |
+| 16 | **HandoffMode** | In Swarm: `NEVER`, `OPTIONAL`, `ALWAYS` | **Coordination pattern selection** | `agent_team_spec.md` | OAS HandoffMode is per-Swarm; Arachne's coordination patterns implicitly encode handoff behavior (handoff pattern = ALWAYS; routing = NEVER; supervisor = OPTIONAL). |
+| 17 | **Datastore** | `datastores/datastore.py` — `RelationalDatastore`, `InMemoryCollectionDatastore`, `OracleDatastore`, `PostgresDatastore` | **KnowledgeBase** (`kind: KnowledgeBase`) + **Conversation Memory** | `arachne_workspace_spec.md`, `architecture.md` §3.1 | Partial mapping. OAS Datastores provide structured data (SQL, collections); Arachne KBs provide RAG retrieval (embeddings + chunks). Arachne conversation memory provides session state. Neither system fully covers the other's use case. |
+| 18 | **Property** | `property.py` — JSON Schema-based input/output definitions | **JSON Schema in tool definitions** | `agent_tools.md` §Tool Manifest | Both use JSON Schema for typing. OAS makes Property a first-class component used across agents, flows, and tools. Arachne uses JSON Schema specifically in tool input/output definitions. |
+| 19 | **Framework Adapter** | `adapters/` — LangGraph, AutoGen, CrewAI adapters | **No equivalent (Arachne IS the runtime)** | — | Arachne doesn't need framework adapters because it is its own execution runtime. OAS needs adapters because it is a spec, not a runtime. |
+| 20 | **Serialization** (to_yaml, to_json, to_dict) | `serialization/` | **Weave pipeline** (YAML → .orb bundle) | `arachne_workspace_spec.md` | OAS serializes components to portable YAML/JSON; Arachne weaves YAML specs into deployable `.orb` bundles. Arachne's format is richer (includes embeddings, chunks, hashes). |
+| 21 | **Version-aware serialization** | `min_agentspec_version`, `max_agentspec_version`, field exclusion by version | **`apiVersion: arachne-ai.com/v0`** | All specs | OAS has fine-grained per-field versioning; Arachne has document-level API versioning. OAS is more sophisticated here. |
+| 22 | **RetryPolicy** | `retrypolicy.py` — retry config for LLM calls | **retryPolicy** on Schedule, DLQ on AgentBus | `agent_scheduling.md`, `agent_messaging.md` | Both support retry with backoff. OAS attaches retry to LLM config; Arachne attaches to scheduling and messaging. |
+| 23 | **Message Transforms** | `transforms/` — pre-LLM message transforms | **Agent application** (`applyAgentToRequest()`) | `architecture.md` §3.1 | Arachne's agent engine performs system prompt injection, skill merging, and RAG context injection — comparable to OAS transforms but not user-extensible as a plugin point. |
+| 24 | **Tracing** | `tracing/` module | **Trace Recorder** + **ACP Trace Reconstruction** | `architecture.md` §3.4, `arachne_communication_protocol_spec.md` §Trace Reconstruction | Arachne's tracing is significantly richer: encrypted at rest, per-tenant isolation, batched async persistence, DAG reconstruction from ACP messages. |
+| 25 | **A2A Agent** | `a2aagent.py` — Agent-to-Agent protocol | **ACP (Arachne Communication Protocol)** | `arachne_communication_protocol_spec.md` | Both define agent-to-agent communication. ACP is more comprehensive: semantic map compression, budget propagation, intent codes, trace reconstruction. |
+| 26 | **MCP Integration** | `mcp/` module | **MCP round-trip** in proxy pipeline | `architecture.md` §3.1 | Both support MCP. Arachne uses MCP for external tool integration (human-facing); ACP for internal agent-to-agent. |
+| 27 | **Evaluation** | `evaluation/` module | **Agent Evaluation Framework** (Phase 3 roadmap) | `product-roadmap.md` §3.1 | Both support agent evaluation. OAS has it now; Arachne has it on the roadmap for June-September 2026. |
+| 28 | — | — | **Multi-tenancy** (Tenant entity, API key isolation, subtenant hierarchy) | `architecture.md` §5 | **No OAS equivalent.** OAS has no concept of tenants, isolation, or multi-user access control. |
+| 29 | — | — | **Encryption at rest** (AES-256-GCM, per-tenant key derivation) | `architecture.md` §10 | **No OAS equivalent.** OAS has no encryption model. |
+| 30 | — | — | **Channels** (named, tenant-scoped pub/sub) | `agent_messaging.md` | **No OAS equivalent.** OAS agents communicate through Swarm relationships or ManagerWorkers hierarchy, not named channels. |
+| 31 | — | — | **Schedule** (cron-based agent execution) | `agent_scheduling.md` | **No OAS equivalent.** OAS focuses on interactive execution, not scheduled/autonomous agent runs. |
+| 32 | — | — | **Workspace** (dependency graph, cross-reference resolution, `.orb` bundles) | `arachne_workspace_spec.md` | **No OAS equivalent.** OAS agents are standalone YAML/JSON definitions without a deployment lifecycle. |
+| 33 | — | — | **Budget Propagation** (token/cost/TTL budgets in ACP) | `arachne_communication_protocol_spec.md` §Budget Propagation | **No OAS equivalent.** OAS has no built-in cost governance. |
+| 34 | — | — | **Conversation Memory** (sliding window, summarization, partitions) | `architecture.md` §3.1 | **No OAS equivalent.** OAS agents are stateless by default; memory is handled by the runtime adapter. |
+
+---
+
+## 3. Translation Examples
+
+### 3.1 Simple Agent Definition
+
+**OAS (YAML export):**
+
+```yaml
+component_type: Agent
+name: support-agent
+description: Customer support specialist
+system_prompt: |
+  You are a customer support agent for {{company_name}}.
+  Help customers with billing and technical issues.
+llm_config:
+  component_type: OpenAiConfig
+  name: gpt-config
+  model_id: gpt-4.1-mini
+tools:
+  - component_type: ServerTool
+    name: lookup-order
+    description: Look up an order by ID
+    inputs:
+      - title: order_id
+        type: string
+    outputs:
+      - title: order_details
+        type: object
+human_in_the_loop: true
+inputs:
+  - title: company_name
+    type: string
+```
+
+**Arachne (YAML spec):**
+
+```yaml
+apiVersion: arachne-ai.com/v0
+kind: Agent
+metadata:
+  name: support-agent
+spec:
+  model: gpt-4.1-mini
+  systemPrompt: |
+    You are a customer support agent for Acme Corp.
+    Help customers with billing and technical issues.
+  knowledgeBaseRef: support-kb
+  toolPackageRef: support-tools
+  channels:
+    subscribe:
+      - customer-intake
+    publish:
+      - resolved-tickets
+```
+
+**Key differences:**
+- OAS uses template variables (`{{company_name}}`); Arachne hardcodes values in the spec (variables resolved at deploy time via tenant config).
+- OAS embeds LLM config and tool definitions inline; Arachne references external artifacts (`knowledgeBaseRef`, `toolPackageRef`) and inherits provider config from the tenant hierarchy.
+- Arachne adds channel wiring and KB references — operational concerns absent from OAS.
+
+---
+
+### 3.2 Multi-Agent Coordination: Supervisor Pattern
+
+**OAS (ManagerWorkers):**
+
+```yaml
+component_type: ManagerWorkers
+name: analysis-team
+group_manager:
+  component_type: Agent
+  name: manager
+  system_prompt: |
+    Coordinate the analysis team. Assign tasks to the
+    appropriate specialist based on the request.
+  llm_config:
+    component_type: OpenAiConfig
+    name: manager-llm
+    model_id: gpt-4.1
+workers:
+  - component_type: Agent
+    name: data-retriever
+    system_prompt: "You retrieve and summarize data..."
+    llm_config:
+      component_type: OpenAiConfig
+      name: retriever-llm
+      model_id: gpt-4.1-mini
+  - component_type: Agent
+    name: analyst
+    system_prompt: "You perform quantitative analysis..."
+    llm_config:
+      component_type: OpenAiConfig
+      name: analyst-llm
+      model_id: gpt-4.1
+```
+
+**Arachne (AgentTeam with supervisor coordination):**
+
+```yaml
+apiVersion: arachne-ai.com/v0
+kind: AgentTeam
+metadata:
+  name: analysis-team
+spec:
+  coordination: supervisor
+  supervisor:
+    agent: manager
+    maxIterations: 5
+    workers:
+      - agent: data-retriever
+        description: "Retrieves and summarizes data"
+      - agent: analyst
+        description: "Performs quantitative analysis"
+  agents:
+    - ref: manager
+    - ref: data-retriever
+    - ref: analyst
+  sharedKnowledgeBases:
+    - company-data-kb
+---
+apiVersion: arachne-ai.com/v0
+kind: Agent
+metadata:
+  name: manager
+spec:
+  model: gpt-4.1
+  systemPrompt: |
+    Coordinate the analysis team. Assign tasks to the
+    appropriate specialist based on the request.
+---
+apiVersion: arachne-ai.com/v0
+kind: Agent
+metadata:
+  name: data-retriever
+spec:
+  model: gpt-4.1-mini
+  systemPrompt: "You retrieve and summarize data..."
+---
+apiVersion: arachne-ai.com/v0
+kind: Agent
+metadata:
+  name: analyst
+spec:
+  model: gpt-4.1
+  systemPrompt: "You perform quantitative analysis..."
+```
+
+**Key differences:**
+- OAS embeds agent definitions inline within the ManagerWorkers component; Arachne defines agents as separate artifacts and references them by name.
+- Arachne adds `maxIterations` safety limit, `sharedKnowledgeBases`, and the `agents` manifest for workspace dependency resolution.
+- Arachne's separation of concerns (each agent is an independently deployable artifact) enables reuse across teams.
+
+---
+
+### 3.3 Swarm → Routing Pattern
+
+**OAS (Swarm with relationships):**
+
+```yaml
+component_type: Swarm
+name: support-swarm
+first_agent:
+  component_type: Agent
+  name: triage
+  system_prompt: "Classify the request and route it."
+  llm_config:
+    component_type: OpenAiConfig
+    name: triage-llm
+    model_id: gpt-4.1-mini
+relationships:
+  - - triage
+    - billing-specialist
+  - - triage
+    - tech-specialist
+handoff: ALWAYS
+```
+
+**Arachne (AgentTeam with routing):**
+
+```yaml
+apiVersion: arachne-ai.com/v0
+kind: AgentTeam
+metadata:
+  name: support-team
+spec:
+  coordination: routing
+  router:
+    agent: triage
+    routes:
+      - intent: billing
+        agent: billing-specialist
+      - intent: technical
+        agent: tech-specialist
+    fallback: general-agent
+  agents:
+    - ref: triage
+    - ref: billing-specialist
+    - ref: tech-specialist
+    - ref: general-agent
+```
+
+**Key differences:**
+- OAS uses pairwise `relationships` tuples; Arachne uses structured `routes` with named intents.
+- Arachne requires a `fallback` agent (defensive design); OAS has no fallback concept.
+- OAS `handoff: ALWAYS` means full conversation context transfer; Arachne's routing passes the original request to the specialist (lighter weight).
+
+---
+
+### 3.4 Flow DAG (OAS-Only — No Arachne Equivalent)
+
+**OAS Flow — no direct Arachne translation exists:**
+
+```yaml
+component_type: Flow
+name: document-processing
+start_node:
+  component_type: StartNode
+  name: start
+  inputs:
+    - title: document_url
+      type: string
+nodes:
+  - component_type: ToolNode
+    name: fetch-doc
+    tool: web.read
+  - component_type: LlmNode
+    name: extract-entities
+    llm_config:
+      component_type: OpenAiConfig
+      name: extraction-llm
+      model_id: gpt-4.1-mini
+    system_prompt: "Extract all named entities..."
+  - component_type: BranchingNode
+    name: check-type
+    branches: [legal, financial, other]
+  - component_type: AgentNode
+    name: legal-review
+    agent: legal-agent
+  - component_type: AgentNode
+    name: financial-review
+    agent: financial-agent
+  - component_type: EndNode
+    name: done
+control_flow_connections:
+  - from: start
+    to: fetch-doc
+  - from: fetch-doc
+    to: extract-entities
+  - from: extract-entities
+    to: check-type
+  - from: check-type
+    to: legal-review
+    branch: legal
+  - from: check-type
+    to: financial-review
+    branch: financial
+  - from: check-type
+    to: done
+    branch: other
+  - from: legal-review
+    to: done
+  - from: financial-review
+    to: done
+data_flow_connections:
+  - from: fetch-doc
+    to: extract-entities
+    mappings:
+      content: document_text
+```
+
+**Arachne approximation (would require a new `kind: Workflow` artifact):**
+
+Arachne cannot currently represent this. The closest approximation uses a supervisor AgentTeam where the supervisor manually orchestrates the steps, but this loses the declarative DAG structure, typed nodes, conditional branching, and data-flow mappings.
+
+---
+
+## 4. Where Arachne's Model Is Richer
+
+| Capability | Arachne | OAS |
+|------------|---------|-----|
+| **Multi-tenancy** | First-class: tenant hierarchy, API key isolation, per-tenant provider config, subtenant rollup analytics | Not addressed — OAS is a spec, not a multi-tenant runtime |
+| **Encryption at rest** | AES-256-GCM with per-tenant key derivation for traces, conversations, provider keys, KB chunks | Not addressed |
+| **Observability / Tracing** | Encrypted trace recording, batched async persistence, monthly partitioning, analytics engine (summary, timeseries, model breakdown) | Basic `tracing/` module — runtime adapter dependent |
+| **Agent Communication Protocol (ACP)** | Token-minimal protocol with semantic map compression (67% savings), budget propagation, intent codes, DAG trace reconstruction | No equivalent — relies on runtime framework for inter-agent messaging |
+| **Budget / Cost Governance** | Token, cost, and TTL budgets propagated through ACP message chain with subdivision and rollup | Not addressed |
+| **Conversation Memory** | Persistent multi-turn conversations with sliding window, automatic summarization, partitions, encrypted storage | Not addressed — stateless agents by default |
+| **Artifact Lifecycle** | Full pipeline: `weave` (validate + bundle) → `push` (registry) → `deploy` (tenant environment), with dependency graph and `.orb` bundles | Serialization to YAML/JSON only — no deployment pipeline |
+| **Workspace / Dependency Graph** | Cross-reference resolution (local workspace first, registry fallback), topological sort, circular dependency detection | Not addressed — components are standalone |
+| **Channels / Named Pub-Sub** | Tenant-scoped channels with broadcast/directed/fan-out patterns, durable messaging with DLQ, declarative channel wiring in agent specs | Not addressed |
+| **Scheduling** | Cron-based agent execution with gateway-initiated and webhook modes, retry policy, concurrency guard | Not addressed |
+| **RAG Pipeline** | KnowledgeBase artifact with embedding, chunking, retrieval (topK, citations), hybrid search (roadmap) | Datastores provide structured data access but not vector search/RAG |
+| **Portal / Dashboard / Admin** | Three web frontends for tenant self-service, operator observability, and system administration | Not addressed — OAS is a spec/SDK, not a product |
+
+---
+
+## 5. Where OAS's Model Is Richer
+
+| Capability | OAS | Arachne |
+|------------|-----|---------|
+| **Flow DAGs** | Full DAG workflow engine with 14+ node types (StartNode, EndNode, AgentNode, LlmNode, ToolNode, ApiNode, BranchingNode, MapNode, ParallelFlowNode, ParallelMapNode, CatchExceptionNode, InputMessageNode, OutputMessageNode, FlowNode), explicit control-flow and data-flow edges, conditional branching, parallel execution, exception handling | 4 fixed coordination patterns (routing, handoff, parallel, supervisor) — no general-purpose workflow DAG |
+| **Framework Adapters** | Adapters for LangGraph, AutoGen, CrewAI — write once, run on any framework | Arachne is a single runtime (no adapter model needed, but also no portability to other frameworks) |
+| **No-code-in-config** | Pure declarative YAML/JSON — no code in the spec itself. Logic is in node types and edges, not custom code | Agent specs are declarative, but tool handlers require JavaScript code in the ToolPackage |
+| **Swarm with Pairwise Relationships** | Fine-grained agent-to-agent relationship graph with 3 handoff modes (NEVER/OPTIONAL/ALWAYS) | AgentTeam patterns are coarser — routing, handoff, parallel, or supervisor. No pairwise relationship graphs |
+| **Per-Field Versioning** | `min_agentspec_version` / `max_agentspec_version` per component, with automatic field exclusion for backward compatibility | Document-level `apiVersion` only — no per-field version awareness |
+| **Template Variables** | `{{variable}}` interpolation in system prompts with typed `Property` inputs | No template variables in agent specs — values are hardcoded or inherited from tenant config |
+| **Component Composition** | Agents, flows, swarms, and ManagerWorkers can be nested and composed arbitrarily | AgentTeam cannot nest (no team-of-teams in MVP) |
+| **Structured Datastores** | SQL databases (Oracle, Postgres) as first-class agent data sources with entity schemas | KnowledgeBases provide document-based RAG only — no structured data source integration |
+| **Human-in-the-Loop** | First-class `human_in_the_loop` flag and `requires_confirmation` on tools | No declarative human-in-the-loop mechanism — handled by client application |
+| **Message Transforms** | Pluggable `MessageTransform` pipeline applied before LLM calls | Agent application is fixed (system prompt injection → skill merging → RAG injection) — not user-extensible |
+| **A2A Protocol** | `a2aagent.py` — standardized agent-to-agent communication protocol | ACP is Arachne-specific (not interoperable with OAS A2A) |
+
+---
+
+## 6. Adoption Strategy Recommendations
+
+### 6.1 Phase 1: OAS Import/Export Compatibility (Low effort, high signal)
+
+**Goal:** Enable Arachne to import OAS YAML agent definitions and export Arachne agent specs as OAS YAML.
+
+**Scope:**
+- Import OAS `Agent` → Arachne `kind: Agent` (map `system_prompt`, `llm_config`, `tools`)
+- Import OAS `ManagerWorkers` → Arachne `kind: AgentTeam` with `coordination: supervisor`
+- Import OAS `Swarm` → Arachne `kind: AgentTeam` with `coordination: routing` (lossy — relationship graph reduced to routes)
+- Export Arachne `kind: Agent` → OAS `Agent` YAML
+- Skip OAS `Flow` import (no Arachne equivalent yet)
+
+**Implementation:**
+- Add `arachne import --format oas <file.yaml>` CLI command
+- Add `arachne export --format oas <artifact>` CLI command
+- Mapping layer handles field name translation and structural transformation
+
+**Value:** Demonstrates interoperability with the OAS ecosystem. Enables migration from OAS-based prototyping to Arachne production deployment.
+
+---
+
+### 6.2 Phase 2: Flow DAG Support (Medium effort, high differentiation)
+
+**Goal:** Add a `kind: Workflow` artifact to Arachne that supports DAG-style orchestration, inspired by OAS Flows.
+
+**Scope:**
+- New artifact kind: `Workflow` (participates in workspace dependency graph above AgentTeam)
+- Node types: `start`, `end`, `agent` (invoke an agent), `tool` (invoke a tool), `branch` (conditional routing), `parallel` (fan-out/fan-in), `transform` (data mapping)
+- Edge types: `controlFlow` (sequence), `dataFlow` (property mapping)
+- Validation: acyclic graph, single start node, typed I/O compatibility between connected nodes
+- Execution: TeamOrchestrator extended with a `WorkflowPattern` that interprets the DAG
+
+**Arachne-native additions (not in OAS):**
+- Budget propagation through workflow nodes (via ACP)
+- Per-node tracing with `parentRequestId` linking
+- Tenant-scoped execution with encryption
+- Channel integration (workflow nodes can publish to channels)
+
+**Value:** Closes the biggest gap in Arachne's orchestration model. Combined with Arachne's operational infrastructure (tenancy, encryption, tracing, budgets), this would create a workflow engine that is both more expressive than the current AgentTeam patterns and more production-ready than OAS Flows.
+
+---
+
+### 6.3 Phase 3: OAS Runtime Adapter (Medium effort, ecosystem play)
+
+**Goal:** Publish an Arachne adapter for OAS, so that OAS-defined agents can run on the Arachne runtime without conversion.
+
+**Scope:**
+- Implement an `ArachneAdapter` that transforms OAS component trees into Arachne runtime calls
+- Register with the OAS adapter ecosystem alongside LangGraph, AutoGen, and CrewAI adapters
+- Support: Agent, ManagerWorkers, Swarm (and Flow if Phase 2 is complete)
+- Arachne-specific features (tenancy, encryption, tracing) are automatically applied
+
+**Value:** Positions Arachne as a first-class OAS runtime alongside WayFlow. Organizations using OAS for agent definitions get Arachne's operational infrastructure for free.
+
+---
+
+### 6.4 Phase 4: Spec Convergence (Long-term, strategic)
+
+**Goal:** Contribute Arachne's differentiating concepts (budgets, channels, scheduling, encryption) back to OAS as optional extensions.
+
+**Scope:**
+- Propose OAS RFCs for: Budget envelope on agents/flows, Channel declarations, Schedule configurations, Encryption policies
+- These would be optional OAS extensions that any OAS-compatible runtime can choose to support
+- Arachne becomes the reference implementation for these extensions
+
+**Value:** Shapes the OAS spec to include production-deployment concerns that are currently absent. Establishes Arachne as a thought leader in the OAS ecosystem.
+
+---
+
+## 7. Risk Assessment
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| OAS spec changes break the import/export layer | Medium | Medium | Pin to OAS version; use version-aware serialization |
+| Flow DAG implementation is more complex than anticipated | High | Medium | Start with the 5 most common node types; defer MapNode and ParallelMapNode |
+| OAS adoption remains Oracle-centric, limiting ecosystem value | Medium | Medium | The import/export layer has standalone value for migration paths |
+| Arachne-specific extensions to OAS are rejected by the community | Low | Medium | Extensions are optional; Arachne benefits regardless of upstream adoption |
+
+---
+
+## 8. Summary
+
+The OAS and Arachne architectures are **complementary, not competitive**. OAS provides a portable specification language for agent definitions; Arachne provides a production-grade runtime for deploying and operating agents. The most impactful adoption path is:
+
+1. **Short-term:** Import/export compatibility to capture OAS-defined agents into Arachne's deployment pipeline
+2. **Medium-term:** Flow DAG support to close Arachne's biggest orchestration gap
+3. **Long-term:** Become an OAS-compatible runtime and contribute operational extensions back to the spec
+
+This positions Arachne as "the place where OAS agents go to production" — a compelling value proposition that leverages both ecosystems.

--- a/docs/system_specs/oas_gap_analysis.md
+++ b/docs/system_specs/oas_gap_analysis.md
@@ -1,0 +1,566 @@
+# OAS Gap Analysis for Arachne
+
+> **Status:** Draft
+> **Author:** Architect (Domain Modeling Expert)
+> **Date:** 2026-04-01
+> **OAS Version Analyzed:** 26.1.0 (nightly)
+> **Arachne Specs Referenced:** architecture.md, product-roadmap.md, feature-roadmap.md, agent_team_spec.md, agent_messaging.md, agent_tools.md, arachne_workspace_spec.md, queue_spike.md
+
+---
+
+## Executive Summary
+
+The Open Agent Specification (OAS) by Oracle defines a portable, platform-agnostic configuration language for describing Agents and Agentic Systems. This analysis compares every OAS concept against Arachne's current capabilities and planned roadmap, classifying each as:
+
+- **(a) Already implemented** — Arachne has equivalent or superior functionality
+- **(b) Partially implemented** — Core concept exists but gaps remain
+- **(c) Not implemented but compatible** — No architectural conflict; can be added
+- **(d) Architectural conflict** — Fundamental design differences that require resolution
+
+**Key findings:**
+- Arachne has strong coverage of Agent definitions, LLM configuration, tool systems, multi-agent patterns, and observability
+- The largest gap is **Flows** — OAS's structured workflow engine (nodes, edges, branching, loops, parallel maps) has no equivalent in Arachne today
+- OAS's **Datastore** abstraction, **Message Transforms**, and **Structured Generation** are partially or not implemented
+- There are **no hard architectural conflicts** — Arachne's design is additive-compatible with OAS concepts
+- Supporting OAS would strengthen Arachne's open-spec positioning and differentiate it from closed runtimes
+
+---
+
+## Classification Legend
+
+| Code | Meaning | Action Required |
+|------|---------|-----------------|
+| **(a)** | Already implemented | Map Arachne concepts to OAS equivalents in an adapter/importer |
+| **(b)** | Partially implemented | Extend existing subsystems to close specific gaps |
+| **(c)** | Not implemented but compatible | Design and build new subsystems; no conflicts with existing architecture |
+| **(d)** | Architectural conflict | Requires design resolution before implementation |
+
+---
+
+## 1. Core Spec Structure
+
+### 1.1 Component Model (Component, ComponentWithIO)
+
+**OAS:** Every entity extends `Component` (id, type, name, description, metadata) and optionally `ComponentWithIO` (adds JSON Schema inputs/outputs). Components reference each other via `$component_ref`.
+
+**Arachne:** Uses `apiVersion`/`kind`/`metadata`/`spec` structure. Artifacts have names and metadata. Cross-references use string refs (e.g., `knowledgeBaseRef: support-kb`).
+
+**Classification: (b) Partially implemented**
+
+| OAS Property | Arachne Equivalent | Gap |
+|---|---|---|
+| `id` | `metadata.name` | Arachne uses name-based identity, not UUID-based. Functional equivalent for workspace scope. |
+| `type` | `kind` | Direct mapping: `Agent`, `KnowledgeBase`, etc. |
+| `name` | `metadata.name` | Same concept |
+| `description` | Not in spec format | Arachne specs lack a `description` field at the artifact level |
+| `metadata` | `metadata` (partial) | Arachne's metadata is limited to `name`; OAS allows arbitrary key-value pairs |
+| `inputs` / `outputs` | Not implemented | Agents and tools don't declare typed I/O schemas in the spec format |
+| `$component_ref` | String refs (`ref: agent-name`) | Functional equivalent within workspaces |
+
+**Gap:** Add `description` and arbitrary `metadata` fields to the spec format. The typed I/O schema (`inputs`/`outputs`) is the larger gap — needed for structured generation and flow data routing.
+
+---
+
+### 1.2 Versioning (`agentspec_version`)
+
+**OAS:** Top-level `agentspec_version` field using `YEAR.QUARTER.PATCH` format (e.g., `26.1.0`). Deprecation cycle of minimum 1 year.
+
+**Arachne:** Uses `apiVersion: arachne-ai.com/v0`. No patch-level versioning. No formal deprecation policy.
+
+**Classification: (b) Partially implemented**
+
+**Gap:** Arachne has version identifiers but lacks the structured versioning scheme and deprecation lifecycle. To support OAS import, Arachne would need to recognize the `agentspec_version` field and validate compatibility.
+
+---
+
+### 1.3 Serialization Format
+
+**OAS:** JSON and YAML with `component_type` discriminators and `$component_ref` for symbolic references. Export/import via `AgentSpecExporter`/`AgentSpecLoader`.
+
+**Arachne:** YAML-based declarative specs with `kind` discriminator. Multi-document YAML and directory workspace formats.
+
+**Classification: (b) Partially implemented**
+
+**Gap:** Add an OAS importer that maps `component_type` → `kind`, resolves `$component_ref` → Arachne string refs, and handles the different nesting conventions. The workspace spec already supports multi-document YAML.
+
+---
+
+## 2. Agent
+
+### 2.1 Agent Definition
+
+**OAS:** Agent with `system_prompt`, `llm_configuration`, `tools`, `toolboxes`, `human_in_the_loop`, `transforms`, and typed I/O.
+
+**Arachne:** Agent with `systemPrompt`, `model`, `skills` (tools), `knowledgeBaseRef`, `mcpEndpoints`. Merge policies for system prompts and skills in tenant hierarchy.
+
+**Classification: (b) Partially implemented**
+
+| OAS Property | Arachne Equivalent | Status |
+|---|---|---|
+| `system_prompt` | `spec.systemPrompt` | **(a)** Direct mapping. Arachne also supports Jinja-like template variables. |
+| `llm_configuration` | `spec.model` + tenant `provider_config` | **(b)** Arachne resolves LLM config from the provider system, not inline. See §3. |
+| `tools` | `spec.skills` + MCP round-trip | **(b)** Tool concept exists but type taxonomy differs. See §4. |
+| `toolboxes` | MCP endpoints (partial) | **(b)** MCP endpoints function as tool discovery containers. No general ToolBox abstraction. |
+| `human_in_the_loop` | Not implemented | **(c)** No HITL gate in the agent execution loop. |
+| `transforms` | Not implemented | **(c)** No message transform pipeline. See §7. |
+| `inputs` / `outputs` | Not implemented | **(c)** No typed I/O on agents. See §1.1. |
+
+**Gap:** `human_in_the_loop` is a new concept requiring a pause/resume mechanism in the agent execution loop. `transforms` require a pre/post-processing pipeline. Typed I/O enables structured generation.
+
+---
+
+### 2.2 SpecializedAgent / AgentSpecializationParameters
+
+**OAS:** A `SpecializedAgent` wraps a base `Agent` with additional instructions, tools, and HITL override. Instructions are merged; tools are extended.
+
+**Arachne:** Subtenant hierarchy provides agent specialization via merge policies (`prepend`, `append`, `overwrite`, `ignore`) for system prompts and skills.
+
+**Classification: (b) Partially implemented**
+
+**Gap:** Arachne's specialization is tenant-scoped (parent/child tenants), not agent-scoped. OAS allows arbitrary agent-to-agent specialization without tenant hierarchy. To support this, Arachne would need an `extends` or `base` field in the Agent spec that references another agent and applies merge rules.
+
+---
+
+## 3. LLM Configuration
+
+### 3.1 LlmConfig Hierarchy
+
+**OAS defines a typed config hierarchy:**
+- `LlmConfig` (base) — generation parameters (`max_tokens`, `temperature`, `top_p`, `stop`, `frequency_penalty`, `extra_args`)
+- `OpenAiCompatibleConfig` — `model_id`, `url`, `api_key`, `api_type`
+- `OpenAiConfig` — OpenAI-specific
+- `OllamaConfig` — extends OpenAiCompatibleConfig
+- `VllmConfig` — extends OpenAiCompatibleConfig
+- `OciGenAiConfig` — Oracle Cloud-specific with compartment, serving mode, OCI auth
+
+**Arachne:** Provider abstraction via `BaseProvider` → `OpenAIProvider`, `AzureProvider` + planned Anthropic, Google, Bedrock, Mistral adapters. LLM config is split between agent `spec.model` and tenant-level `provider_config`.
+
+**Classification: (b) Partially implemented**
+
+| OAS Config | Arachne Equivalent | Status |
+|---|---|---|
+| `OpenAiConfig` | `OpenAIProvider` | **(a)** |
+| `OllamaConfig` | Ollama adapter (OpenAI-compatible) | **(a)** |
+| `OpenAiCompatibleConfig` | Bridge adapter (planned, Phase 1) | **(b)** Provider Bridge Adapter (#112) covers this |
+| `VllmConfig` | Bridge adapter | **(b)** Same as above |
+| `OciGenAiConfig` | Not implemented | **(c)** Oracle-specific; no conflict. Could be added as a new provider adapter. |
+| Generation parameters | Passed through to provider | **(b)** `temperature`, `max_tokens` etc. are supported as request body fields but not declared in the agent spec |
+
+**Gap:** Arachne's LLM config is resolved at runtime from the provider system, not declared inline in the agent spec. To support OAS, Arachne would need to either (a) accept inline `llm_configuration` in specs and translate to provider config at deploy time, or (b) provide a mapping layer in the OAS importer. Generation parameters should be declarable per-agent in the spec format.
+
+---
+
+## 4. Tools
+
+### 4.1 Tool Type Taxonomy
+
+**OAS defines 5 tool types:**
+
+| OAS Tool Type | Description | Arachne Equivalent | Status |
+|---|---|---|---|
+| `ServerTool` | Server-side execution; implementation outside spec | ToolPackage handlers (Azure Container Apps Dynamic Sessions) | **(b)** Arachne's tool host executes sandboxed JS handlers. Concept aligns but packaging differs. |
+| `ClientTool` | Client-side execution; runtime pauses and returns `ToolRequest` | Not implemented | **(c)** Requires pause/resume in agent loop (like HITL). |
+| `RemoteTool` | HTTP API call with URL, method, headers, query params | Not directly supported | **(c)** Closest is MCP round-trip, but RemoteTool is simpler HTTP. Could be a built-in tool type. |
+| `MCPTool` | Tool via MCP protocol | MCP endpoints + round-trip | **(a)** Arachne already supports MCP tool calls. |
+| `BuiltinTool` | Runtime-provided tool by identifier | Not implemented as a concept | **(c)** No built-in tool registry. Compatible — just needs a registry mapping. |
+
+**Classification: (b) Partially implemented**
+
+**Gap:** Arachne needs `ClientTool` (pause/resume), `RemoteTool` (declarative HTTP tool), and `BuiltinTool` (runtime tool registry). The `ServerTool` concept maps to ToolPackages but the OAS version doesn't include executable code — it's a declaration that says "this tool exists server-side."
+
+---
+
+### 4.2 Tool Properties
+
+**OAS:** Tools have `inputs` (JSON Schema), `outputs` (JSON Schema), `requires_confirmation` (bool).
+
+**Arachne:** Tool manifest has `input_schema`, `output_schema`, handler path. No `requires_confirmation` field.
+
+**Classification: (b) Partially implemented**
+
+**Gap:** Add `requires_confirmation` to tool manifest (maps to HITL gate before tool execution). Input/output schemas are conceptually the same.
+
+---
+
+### 4.3 ToolBox / MCPToolBox
+
+**OAS:** `ToolBox` is a discovery/aggregation container. `MCPToolBox` connects to an MCP server via transport and optionally filters tools with `tool_filter` (name list or `MCPToolSpec` validation).
+
+**Arachne:** MCP endpoints on agents (`spec.mcpEndpoints`) function as tool discovery. No filtering or validation of discovered tools.
+
+**Classification: (b) Partially implemented**
+
+**Gap:** Add `tool_filter` support to MCP endpoint configuration — allow agents to whitelist specific tools from an MCP server and optionally validate their schemas.
+
+---
+
+### 4.4 MCP Transport Types
+
+**OAS defines transport types:**
+
+| Transport | Arachne Support | Status |
+|---|---|---|
+| `StdioTransport` (command, args, env, cwd) | Not implemented | **(c)** Requires local process spawning |
+| `SSETransport` (url, headers) | MCP endpoints use SSE | **(a)** |
+| `StreamableHTTPTransport` (url, headers) | Not implemented | **(c)** Newer MCP transport |
+| `SSEmTLSTransport` (mTLS) | Not implemented | **(c)** |
+| `StreamableHTTPmTLSTransport` (mTLS) | Not implemented | **(c)** |
+
+**Classification: (b) Partially implemented**
+
+**Gap:** Arachne supports SSE-based MCP but lacks Stdio, StreamableHTTP, and mTLS transports. Stdio is important for local development; StreamableHTTP is the latest MCP transport evolution.
+
+---
+
+## 5. Flows (Structured Workflows)
+
+### 5.1 Flow Definition
+
+**OAS:** `Flow` is a graph-based workflow with `start_node`, `nodes`, `control_flow_connections` (edges for execution order), and `data_flow_connections` (edges for data routing). Flows have typed I/O, shared conversation model, and separate I/O data space.
+
+**Arachne:** No flow/workflow concept. Agent execution is single-pass request/response with optional MCP tool round-trip. Multi-agent coordination uses the AgentTeam spec with four fixed patterns (routing, handoff, parallel, supervisor).
+
+**Classification: (c) Not implemented but compatible**
+
+**This is the largest gap in the analysis.** OAS Flows provide a general-purpose workflow engine that subsumes Arachne's four AgentTeam coordination patterns and adds significantly more flexibility.
+
+**Gap analysis for Flow components:**
+
+| OAS Flow Concept | Arachne Equivalent | Status |
+|---|---|---|
+| `Flow` (graph container) | None | **(c)** |
+| `StartNode` | None | **(c)** |
+| `EndNode` | None | **(c)** |
+| `LlmNode` | None (agent handles LLM calls) | **(c)** |
+| `ToolNode` | Tool invocation in agent loop | **(b)** Exists as part of agent execution, not as standalone node |
+| `AgentNode` | Sub-agent invocation in TeamOrchestrator | **(b)** |
+| `FlowNode` (sub-flow) | None | **(c)** |
+| `BranchingNode` | Router coordination pattern | **(b)** Routing pattern is a specific case |
+| `MapNode` (sequential iteration) | None | **(c)** |
+| `ParallelMapNode` (parallel iteration) | None | **(c)** |
+| `ParallelFlowNode` (parallel sub-flows) | Parallel coordination pattern | **(b)** Limited to workers + merge |
+| `InputMessageNode` | None | **(c)** |
+| `OutputMessageNode` | None | **(c)** |
+| `ApiNode` | None (could use RemoteTool) | **(c)** |
+| `CatchExceptionNode` | None | **(c)** |
+| `ControlFlowEdge` | Implicit in coordination patterns | **(b)** |
+| `DataFlowEdge` | Implicit in pipeline message passing | **(b)** |
+| `Variable` (flow-scoped state) | None | **(c)** |
+| `VariableReadStep` / `VariableWriteStep` | None | **(c)** |
+
+**Recommendation:** Implementing a full Flow engine is a significant undertaking. The pragmatic approach:
+
+1. **Phase 1:** Build an OAS-to-AgentTeam translator that maps simple OAS flows to Arachne's existing coordination patterns where possible.
+2. **Phase 2:** Implement a general-purpose `Flow` artifact kind with a node/edge execution engine. This would subsume and eventually replace the fixed coordination patterns in AgentTeam.
+3. **Phase 3:** Add the full node standard library (MapNode, ParallelMapNode, BranchingNode, CatchExceptionNode, etc.).
+
+---
+
+### 5.2 AgentTeam Patterns vs. OAS Multi-Agent Patterns
+
+**OAS multi-agent patterns:**
+
+| OAS Pattern | Arachne Equivalent | Status |
+|---|---|---|
+| `Swarm` (directed agent graph with handoff modes: never/optional/always) | Routing + Handoff patterns | **(b)** Arachne's routing and handoff are subsets of Swarm. Missing: optional/always handoff modes, arbitrary agent-to-agent relationships. |
+| `ManagerWorkers` (manager routes tasks, workers report back) | Supervisor pattern | **(b)** Supervisor is functionally equivalent. Missing: workers cannot interact with end user (OAS enforces this; Arachne doesn't distinguish). |
+
+**Classification: (b) Partially implemented**
+
+**Gap:** Arachne's four fixed coordination patterns (routing, handoff, parallel, supervisor) cover the most common multi-agent scenarios but lack:
+- Swarm's arbitrary relationship graph (Arachne's routing is strictly one-router-to-many-specialists)
+- Handoff modes (never/optional/always) — Arachne handoff is always "always" (strict pipeline)
+- Worker isolation from end-user (OAS ManagerWorkers explicitly prevents workers from responding to users)
+
+---
+
+## 6. Datastores
+
+### 6.1 Datastore Abstraction
+
+**OAS defines datastore types:**
+
+| OAS Datastore | Arachne Equivalent | Status |
+|---|---|---|
+| `InMemoryCollectionDatastore` | None | **(c)** No agent-accessible key-value store |
+| `OracleDatabaseDatastore` | None | **(c)** Oracle-specific |
+| `PostgresDatabaseDatastore` | PostgreSQL (internal, not agent-accessible) | **(c)** Arachne uses Postgres for its own data, but doesn't expose database access to agents as a tool |
+
+**Classification: (c) Not implemented but compatible**
+
+**Gap:** OAS Datastores are typed, agent-accessible data stores with schema definitions and CRUD operations (DatastoreListStep, DatastoreCreateStep, etc.). Arachne's PostgreSQL is internal infrastructure, not an agent-facing capability. To support this:
+
+1. Add a `Datastore` artifact kind with entity schema definitions
+2. Provide built-in tools for CRUD operations on datastores
+3. Wire into agent execution so agents can read/write structured data
+
+This aligns with Arachne's roadmap item "Advanced Memory Strategies" (#127) — entity extraction and persistent facts could be implemented as a datastore.
+
+---
+
+## 7. Message Transforms
+
+### 7.1 Transform Pipeline
+
+**OAS:** `MessageTransform` is an abstract pre/post-processing step on agent messages. Concrete types:
+- `MessageSummarizationTransform` — summarize individual messages exceeding size limit
+- `ConversationSummarizationTransform` — summarize conversation when message count exceeds threshold
+
+Both support LLM-based summarization with configurable instructions and caching via datastores.
+
+**Arachne:** Conversation memory includes automatic summarization when token budget is exceeded (snapshot creation). No configurable transform pipeline.
+
+**Classification: (b) Partially implemented**
+
+| OAS Transform | Arachne Equivalent | Status |
+|---|---|---|
+| `ConversationSummarizationTransform` | Token-budget summarization with snapshots | **(b)** Same concept; Arachne triggers on token count, OAS on message count. Missing: configurable summarization instructions, datastore-backed caching. |
+| `MessageSummarizationTransform` | Not implemented | **(c)** Per-message summarization is a new concept |
+
+**Gap:** Arachne's summarization is hardcoded into `ConversationManagementService`. To support OAS transforms:
+1. Extract summarization logic into a pluggable `MessageTransform` interface
+2. Allow agents to declare transforms in their spec
+3. Add per-message summarization as a new transform type
+4. Support configurable summarization instructions (roadmap item "Configurable Summarization" 5.2)
+
+---
+
+## 8. Structured Generation
+
+**OAS:** When an Agent or LlmNode defines multiple or non-string output properties, the runtime triggers structured generation — the LLM produces JSON matching the output schema in a single request.
+
+**Arachne:** No structured generation support. Agents return free-form text. The router agent in the routing pattern produces structured output (intent classification), but this is implicit, not schema-driven.
+
+**Classification: (c) Not implemented but compatible**
+
+**Gap:** Add support for `outputs` on Agent specs. When outputs are defined, inject JSON Schema into the LLM request as `response_format` (OpenAI) or equivalent provider-specific structured output parameter.
+
+---
+
+## 9. Remote / External Agents
+
+### 9.1 RemoteAgent / A2AAgent
+
+**OAS:** `RemoteAgent` executes logic outside the current process. `A2AAgent` implements Google's Agent-to-Agent protocol with URL, connection config (including mTLS), and session parameters.
+
+**Arachne:** No remote agent concept. All agents execute within the Arachne runtime. Cross-tenant agent references are a future extension in the AgentTeam spec.
+
+**Classification: (c) Not implemented but compatible**
+
+**Gap:** Add a `RemoteAgent` artifact kind or agent type that proxies requests to external agent endpoints. A2A protocol support would require an HTTP client adapter. This aligns with the "Cross-Tenant Agent References" future extension in agent_team_spec.md.
+
+---
+
+### 9.2 OciAgent
+
+**OAS:** Oracle Cloud Infrastructure agent endpoint with `agent_endpoint_id` and `OciClientConfig`.
+
+**Arachne:** No OCI integration.
+
+**Classification: (c) Not implemented but compatible**
+
+**Gap:** Vendor-specific. Low priority unless targeting OCI customers. Could be implemented as a RemoteAgent variant.
+
+---
+
+## 10. Observability / Tracing
+
+### 10.1 Tracing Model
+
+**OAS defines:**
+- Events (point-in-time), Spans (time-bounded), Traces (execution trees)
+- 7 span types: LlmGeneration, ToolExecution, AgentExecution, SwarmExecution, ManagerWorkersExecution, FlowExecution, NodeExecution
+- SpanProcessors for consumption hooks
+- Security: sensitive field masking
+
+**Arachne:** Batched trace recording with fire-and-forget persistence. Traces include request/response bodies (encrypted), token counts, latency, cost estimation. Sub-agent invocations in AgentTeam produce linked traces via `parentRequestId`.
+
+**Classification: (b) Partially implemented**
+
+| OAS Concept | Arachne Equivalent | Status |
+|---|---|---|
+| Trace (execution tree) | Trace rows with `parentRequestId` | **(a)** |
+| LlmGenerationSpan | Trace row for LLM request/response | **(a)** |
+| ToolExecutionSpan | Tool execution record (agent_tools spec) | **(a)** |
+| AgentExecutionSpan | Trace row per agent invocation | **(a)** |
+| SwarmExecutionSpan | Not implemented (no Swarm) | **(c)** |
+| ManagerWorkersExecutionSpan | Team-level trace with `teamRole` | **(b)** |
+| FlowExecutionSpan | Not implemented (no Flows) | **(c)** |
+| NodeExecutionSpan | Not implemented (no Flows) | **(c)** |
+| SpanProcessors | EventBus subscribers | **(b)** EventBus supports fire-and-forget events; not structured as span processors |
+| Sensitive field masking | AES-256-GCM encryption at rest | **(a)** Arachne encrypts everything; OAS masks selectively |
+
+**Gap:** Arachne's tracing is well-developed. The gaps are Flow/Node spans (blocked on Flow implementation) and structured SpanProcessor hooks. Arachne's approach of encrypting everything at rest is actually stronger than OAS's selective masking.
+
+---
+
+## 11. Security / Sensitive Data
+
+**OAS:** `SensitiveField[T]` wrapper type. Sensitive fields excluded from serialized exports. No executable code in representations.
+
+**Arachne:** Per-tenant AES-256-GCM encryption for all data at rest. Provider API keys stored in `encrypted:{ciphertext}:{iv}` format. No `SensitiveField` wrapper in spec format.
+
+**Classification: (b) Partially implemented**
+
+**Gap:** Arachne's encryption is more comprehensive than OAS's `SensitiveField` approach (Arachne encrypts everything, not just marked fields). For OAS compatibility, add `SensitiveField` annotation support in the spec format and ensure such fields are stripped when exporting/publishing specs.
+
+---
+
+## 12. Human-in-the-Loop (HITL)
+
+**OAS:** `human_in_the_loop` flag on Agent. `requires_confirmation` flag on Tools. Runtime pauses and returns status (`UserMessageRequestStatus`, `ToolExecutionConfirmationStatus`).
+
+**Arachne:** No HITL support. All agent and tool executions are fully automated.
+
+**Classification: (c) Not implemented but compatible**
+
+**Gap:** HITL requires:
+1. A pause/resume mechanism in the agent execution loop
+2. A status API for pending confirmations (`GET /v1/confirmations`)
+3. A confirmation endpoint (`POST /v1/confirmations/:id/approve`)
+4. Webhook notification when HITL is triggered
+5. Timeout handling for unconfirmed requests
+
+This is compatible with Arachne's architecture but requires significant new infrastructure. Could leverage the webhook system (roadmap Phase 2, #123).
+
+---
+
+## 13. Prompt Templates
+
+**OAS:** Jinja2 templates with `{{variable}}` placeholders. Special placeholders: `__CHAT_HISTORY__`, `__RESPONSE_FORMAT__`, `__TOOLS__`. Output parsers: RegexOutputParser, JsonOutputParser, ReactToolOutputParser.
+
+**Arachne:** System prompts support template variables (merged from tenant hierarchy). No output parsers.
+
+**Classification: (b) Partially implemented**
+
+**Gap:** Add Jinja2-compatible template processing for system prompts. Add output parser support for structured extraction from LLM responses. The special placeholders (`__CHAT_HISTORY__`, etc.) map to concepts Arachne already handles internally (history injection, tool injection) but aren't exposed in the template language.
+
+---
+
+## 14. Parallelization
+
+**OAS:** Explicit parallelization rules — no ordering guarantees, no shared state writes, no user I/O in parallel branches. `ParallelMapNode` and `ParallelFlowNode` for concurrent execution.
+
+**Arachne:** Parallel coordination pattern in AgentTeam runs workers concurrently via `Promise.all`. No formal parallelization rules or constraints.
+
+**Classification: (b) Partially implemented**
+
+**Gap:** Arachne's parallel pattern is functional but lacks:
+- Formal constraint validation (e.g., detecting shared state writes in parallel branches)
+- ParallelMapNode semantics (iterate over a list in parallel with reducers)
+- ParallelFlowNode semantics (run independent sub-flows concurrently)
+
+---
+
+## 15. Runtime Adapters
+
+**OAS:** Designed for cross-framework portability. Adapters exist for WayFlow, LangGraph, AutoGen, CrewAI.
+
+**Arachne:** Single runtime (Arachne's Fastify-based server). No adapter concept.
+
+**Classification: (c) Not implemented but compatible**
+
+**Gap:** Building an OAS adapter for Arachne would allow OAS-defined agents to run on Arachne's runtime. This is the integration point — not a gap in Arachne per se, but the deliverable that makes OAS support real.
+
+---
+
+## Summary Matrix
+
+| # | OAS Concept | Classification | Priority | Blocked By |
+|---|---|---|---|---|
+| 1.1 | Component model (id, type, metadata) | **(b)** Partial | Medium | — |
+| 1.2 | Versioning (`agentspec_version`) | **(b)** Partial | Low | — |
+| 1.3 | Serialization (JSON/YAML, `$component_ref`) | **(b)** Partial | Medium | OAS importer |
+| 2.1 | Agent definition | **(b)** Partial | High | Typed I/O, transforms |
+| 2.2 | SpecializedAgent | **(b)** Partial | Medium | Agent `extends` field |
+| 3.1 | LLM Configuration hierarchy | **(b)** Partial | Medium | Inline LLM config in spec |
+| 4.1 | Tool type taxonomy (5 types) | **(b)** Partial | High | ClientTool, RemoteTool, BuiltinTool |
+| 4.2 | Tool confirmation (`requires_confirmation`) | **(c)** Not impl. | Medium | HITL system |
+| 4.3 | ToolBox / MCPToolBox | **(b)** Partial | Medium | Tool filtering |
+| 4.4 | MCP transports (Stdio, StreamableHTTP, mTLS) | **(b)** Partial | Medium | — |
+| 5.1 | **Flows (full workflow engine)** | **(c)** Not impl. | **Critical** | Flow engine design |
+| 5.2 | Multi-agent patterns (Swarm, ManagerWorkers) | **(b)** Partial | High | Swarm relationship graph |
+| 6.1 | Datastores (typed, agent-accessible) | **(c)** Not impl. | Medium | Datastore artifact kind |
+| 7.1 | Message transforms | **(b)** Partial | Medium | Transform pipeline |
+| 8.0 | Structured generation | **(c)** Not impl. | High | Typed I/O on agents |
+| 9.1 | RemoteAgent / A2AAgent | **(c)** Not impl. | Medium | Remote agent proxy |
+| 9.2 | OciAgent | **(c)** Not impl. | Low | — |
+| 10.1 | Tracing (7 span types, processors) | **(b)** Partial | Low | Flow spans |
+| 11.0 | SensitiveField | **(b)** Partial | Low | — |
+| 12.0 | Human-in-the-loop | **(c)** Not impl. | High | Pause/resume mechanism |
+| 13.0 | Prompt templates (Jinja2, output parsers) | **(b)** Partial | Medium | — |
+| 14.0 | Parallelization rules | **(b)** Partial | Low | Flow engine |
+| 15.0 | Runtime adapter | **(c)** Not impl. | **Critical** | OAS importer/runtime |
+
+---
+
+## Recommended Implementation Sequence
+
+### Phase A: OAS Compatibility Layer (2-3 sprints)
+
+Build an OAS importer/adapter without changing Arachne's core architecture:
+
+1. **OAS Spec Importer** — Parse OAS JSON/YAML, map to Arachne spec format
+   - Map `Agent` → Arachne `Agent` (system_prompt, model, tools)
+   - Map `llm_configuration` → provider config
+   - Map `ServerTool`/`MCPTool` → Arachne tool/MCP definitions
+   - Map `Swarm` → AgentTeam (routing or supervisor)
+   - Map `ManagerWorkers` → AgentTeam (supervisor)
+2. **OAS Spec Exporter** — Export Arachne specs as OAS format
+3. **`arachne import` CLI command** — Import OAS specs into workspace
+
+### Phase B: Core Gaps (3-4 sprints)
+
+Close the most impactful gaps:
+
+1. **Typed I/O on Agents** — Add `inputs`/`outputs` to Agent spec; enable structured generation
+2. **RemoteTool** — Declarative HTTP tool type (url, method, headers)
+3. **HITL System** — Pause/resume mechanism, confirmation API, `requires_confirmation` on tools
+4. **Message Transform Pipeline** — Pluggable pre/post-processing on agent messages
+5. **Expanded MCP Transports** — Stdio and StreamableHTTP support
+
+### Phase C: Flow Engine (4-6 sprints)
+
+The largest investment, but also the highest strategic value:
+
+1. **Flow artifact kind** — Graph container with StartNode, EndNode, typed I/O
+2. **Core node types** — LlmNode, ToolNode, AgentNode, BranchingNode
+3. **Control flow edges** — Sequential execution with branching
+4. **Data flow edges** — Typed data routing between nodes
+5. **FlowNode** (sub-flows) and **ParallelFlowNode**
+6. **MapNode / ParallelMapNode** — Iteration with reducers
+7. **CatchExceptionNode** — Error handling in flows
+8. **Variables** — Flow-scoped shared state with read/write steps
+
+### Phase D: Extended Capabilities (2-3 sprints)
+
+Lower-priority items that complete full OAS coverage:
+
+1. **Datastore artifact kind** — Agent-accessible typed data stores
+2. **BuiltinTool registry** — Runtime-provided tool catalog
+3. **ClientTool** — Client-side tool execution with pause/resume
+4. **OAS versioning support** — `agentspec_version` validation
+5. **SensitiveField annotation** — Mark fields for exclusion from exports
+
+---
+
+## Architectural Notes
+
+### No Hard Conflicts
+
+Arachne's architecture is fundamentally compatible with OAS. The key reasons:
+
+1. **Additive spec format** — Arachne's `apiVersion`/`kind`/`metadata`/`spec` structure can accommodate new fields and kinds without breaking existing artifacts.
+2. **Provider abstraction** — Arachne's `BaseProvider` pattern can map to any OAS `LlmConfig` variant.
+3. **Workspace system** — Cross-reference resolution, dependency ordering, and multi-artifact coordination are already built.
+4. **Registry/CLI pipeline** — The weave/push/deploy lifecycle works for any artifact kind.
+
+### Strategic Considerations
+
+1. **Flows vs. AgentTeam** — Long-term, a general-purpose Flow engine could subsume AgentTeam's four fixed patterns. AgentTeam would become syntactic sugar for common flow patterns. This reduces maintenance burden and increases flexibility.
+
+2. **OAS as import format, not replacement** — Arachne should support OAS import/export while maintaining its own spec format. The Arachne spec format is optimized for Arachne's deployment model (multi-tenant, provider-agnostic, encrypted). OAS is a portability format.
+
+3. **Differentiation through runtime** — OAS explicitly decouples spec from runtime. Arachne's value add is the runtime: multi-tenant isolation, encryption, observability, provider routing. Supporting OAS specs makes Arachne's runtime accessible to the broader OAS ecosystem.
+
+4. **Open spec alignment** — Arachne's roadmap includes "Open Spec Governance" (Phase 4, #133). Aligning with or contributing to OAS could accelerate community adoption and reduce the burden of maintaining a proprietary spec format.

--- a/docs/system_specs/workflow_editor_spec.md
+++ b/docs/system_specs/workflow_editor_spec.md
@@ -1,0 +1,1319 @@
+# Arachne Workflow Editor Specification
+
+> Tracked by Epic [#TBD]
+
+## Status
+
+Draft -- MVP Specification
+
+**Author:** Arachne Team (Trinity, UX Architect)
+**Last Updated:** 2026-04-01
+
+------------------------------------------------------------------------
+
+## 1. Overview
+
+The **Workflow Editor** is a visual drag-and-drop canvas for building,
+editing, and debugging multi-agent workflows within the Arachne Portal
+UI. It provides a node-graph interface where each node represents an
+Arachne runtime concept (LLM call, tool invocation, conditional branch,
+etc.) and edges represent data and control flow between steps.
+
+Workflows built in the editor serialize to Arachne's declarative YAML
+format (the same format consumed by the CLI's `arachne weave` pipeline)
+and can be deployed through the standard artifact lifecycle. The editor
+also supports live execution visualization, enabling operators to watch
+token flow, budget consumption, and agent-to-agent messaging in real
+time.
+
+### 1.1 Design Goals
+
+1. **Visual-first authoring.** Non-developer operators should be able to
+   assemble agent workflows without writing YAML by hand.
+2. **Round-trip fidelity.** YAML authored by hand or by the editor
+   produces identical runtime behavior. The editor never introduces
+   constructs the CLI cannot process.
+3. **Arachne-native.** Node types map 1:1 to Arachne runtime concepts
+   (Agent, AgentTeam coordination patterns, channels, schedules, KBs).
+   The editor is not a generic flowchart tool.
+4. **Observable.** Execution traces overlay directly on the canvas.
+   Operators see which nodes fired, latency per node, token usage, and
+   errors -- without leaving the editor.
+5. **Tenant-scoped.** Workflows are tenant-owned artifacts, encrypted at
+   rest, and subject to the same access control as other Arachne
+   resources.
+6. **Incrementally adoptable.** Users can import existing YAML specs
+   into the editor and export editor workflows as YAML. Neither path is
+   a one-way door.
+
+### 1.2 Non-Goals (MVP)
+
+- Collaborative real-time editing (multiplayer cursors).
+- Version history / diff view (deferred to Phase 2).
+- Custom node plugin system for tenant-defined node types.
+- Mobile / tablet layout optimization.
+
+------------------------------------------------------------------------
+
+## 2. Technology Choice
+
+### 2.1 React Flow (@xyflow/react)
+
+The editor is built on **React Flow** (`@xyflow/react`), MIT licensed.
+
+**Why React Flow:**
+
+| Criterion | React Flow | Alternatives (rete.js, Flume, raw SVG) |
+|-----------|------------|----------------------------------------|
+| License | MIT | Varies (some GPL) |
+| React integration | Native (hooks, context) | Wrapper layers required |
+| Custom node rendering | Full React component per node | Limited or template-based |
+| Minimap, controls, background | Built-in plugins | Must build or import |
+| Performance (1,000+ nodes) | Viewport culling, virtualized | Manual optimization |
+| Community & maintenance | 20K+ GitHub stars, active | Smaller communities |
+| Edge customization | Custom edge components, markers | Limited |
+| Undo/redo ecosystem | Compatible with `use-undo`, Zustand | Varies |
+| Touch/trackpad support | Built-in pan, zoom, selection | Varies |
+
+React Flow integrates directly into the existing Portal SPA (Vite +
+React) with no additional build tooling.
+
+### 2.2 State Management
+
+Workflow editor state is managed via **Zustand** (already available in
+the Portal dependency tree) with an undo/redo middleware layer.
+
+```
+WorkflowEditorStore (Zustand)
+  ├── nodes: Node[]              # React Flow nodes
+  ├── edges: Edge[]              # React Flow edges
+  ├── selectedNodeId: string | null
+  ├── workflowMeta: WorkflowMeta # name, description, tenant, version
+  ├── validationErrors: ValidationError[]
+  ├── executionState: ExecutionOverlay | null
+  ├── undoStack: Patch[]
+  ├── redoStack: Patch[]
+  └── actions:
+      ├── addNode(type, position)
+      ├── removeNode(id)
+      ├── updateNodeData(id, data)
+      ├── addEdge(source, target, type)
+      ├── removeEdge(id)
+      ├── undo()
+      ├── redo()
+      ├── validate()
+      ├── serialize() → WorkflowYAML
+      ├── deserialize(yaml) → void
+      └── applyExecutionOverlay(trace)
+```
+
+------------------------------------------------------------------------
+
+## 3. Node Types
+
+Every node type maps to a concrete Arachne runtime concept. Nodes are
+rendered as custom React components with type-specific icons, ports
+(handles), and inline configuration summaries.
+
+### 3.1 Node Type Catalog
+
+| Node Type | Arachne Concept | Input Ports | Output Ports | Description |
+|-----------|----------------|-------------|--------------|-------------|
+| **Start** | Workflow entry point | -- | 1 (control) | Defines the workflow trigger (API request, schedule, webhook, channel message). Exactly one per workflow. |
+| **End** | Workflow termination | 1+ (control) | -- | Marks a terminal state. Returns the final response to the caller. Multiple End nodes allowed (for branching paths). |
+| **LLM Call** | Agent invocation | 1 (control), 0+ (data) | 1 (control), 1 (data: response) | Invokes a deployed agent or inline LLM configuration. Configurable: model, system prompt, temperature, max tokens. |
+| **Tool Invocation** | MCP tool call | 1 (control), 0+ (data) | 1 (control), 1 (data: result) | Calls an MCP-registered tool or ToolPackage function. Tool discovery via Arachne's MCP registry. |
+| **Conditional Branch** | If/else routing | 1 (control), 1 (data: condition input) | 2+ (control: labeled branches) | Evaluates a condition expression against incoming data. Routes to one of N labeled output branches. |
+| **Router** | AgentTeam routing pattern | 1 (control) | N (control: one per route + fallback) | Wraps the `coordination: routing` pattern. Router agent classifies intent; each output port maps to a route. |
+| **Handoff** | AgentTeam handoff pattern | 1 (control) | 1 (control) | Sequential pipeline. Internal stages are configured in the property panel (ordered list of agents). |
+| **Parallel Fan-Out** | AgentTeam parallel pattern | 1 (control) | N (control: one per worker) | Dispatches the same input to N worker agents concurrently. Must pair with a Fan-In node. |
+| **Parallel Fan-In** | Merge step | N (control: one per worker) | 1 (control), 1 (data: merged result) | Collects outputs from parallel workers. Configurable merge agent and strategy. |
+| **Supervisor** | AgentTeam supervisor pattern | 1 (control) | 1 (control) | Dynamic loop: supervisor agent invokes workers via tool calls until satisfied. Max iterations configurable. |
+| **Human-in-the-Loop (HITL)** | Approval gate | 1 (control), 1 (data: review payload) | 2 (control: approved, rejected) | Pauses execution and presents data to a human reviewer via the Portal UI or webhook. Resumes on approval/rejection. |
+| **Memory / RAG** | KnowledgeBase retrieval | 1 (control), 1 (data: query) | 1 (control), 1 (data: retrieved context) | Performs RAG retrieval against a deployed KnowledgeBase. Configurable: KB ref, top-k, similarity threshold. |
+| **Transform** | Data transformation | 1 (control), 1+ (data) | 1 (control), 1 (data: transformed) | Applies a JavaScript expression, Handlebars template, or JSONPath transform to reshape data between nodes. |
+| **Subflow** | Nested workflow reference | 1 (control), 0+ (data) | 1 (control), 0+ (data) | References another saved workflow by name. Enables composition and reuse. Resolved at weave time. |
+| **Trigger** | Schedule / event source | -- | 1 (control) | Alternative to Start for scheduled or event-driven workflows. Configurable: cron expression, webhook URL, channel subscription. |
+| **Channel Send** | AgentBus message publish | 1 (control), 1 (data: message) | 1 (control) | Publishes a message to a named channel (broadcast or directed). |
+| **Channel Receive** | AgentBus message subscribe | -- | 1 (control), 1 (data: message) | Subscribes to a named channel. Acts as a trigger for event-driven subflows. |
+| **Delay** | Timer / wait | 1 (control) | 1 (control) | Pauses execution for a configurable duration (seconds). Useful for rate limiting or timed sequences. |
+
+### 3.2 Node Anatomy
+
+Each node renders as a custom React Flow component with a consistent
+visual structure:
+
+```
+┌─────────────────────────────────┐
+│ [icon]  Node Type Label    [?]  │  ← Header (type icon, name, help)
+├─────────────────────────────────┤
+│                                 │
+│  Agent: billing-agent           │  ← Summary (key config, read-only)
+│  Model: gpt-4.1-mini           │
+│  KB: company-policies           │
+│                                 │
+├─────────────────────────────────┤
+│  ● input    ○ control-out       │  ← Ports (handles)
+│  ● data-in  ○ data-out          │
+└─────────────────────────────────┘
+```
+
+**Visual coding by type:**
+
+| Category | Color | Node Types |
+|----------|-------|------------|
+| Flow control | Slate/gray | Start, End, Conditional Branch, Delay |
+| Agent execution | Blue | LLM Call, Router, Handoff, Supervisor |
+| Parallel | Purple | Fan-Out, Fan-In |
+| Data | Green | Transform, Memory/RAG |
+| Integration | Orange | Tool Invocation, Channel Send/Receive |
+| Human | Amber | HITL |
+| Composition | Teal | Subflow, Trigger |
+
+### 3.3 Port (Handle) Types
+
+React Flow handles are typed to enforce valid connections:
+
+| Port Type | Visual | Can Connect To | Description |
+|-----------|--------|---------------|-------------|
+| `control-in` | Solid circle, left | `control-out` | Execution flow input |
+| `control-out` | Open circle, right | `control-in` | Execution flow output |
+| `data-in` | Solid diamond, left | `data-out` | Data dependency input |
+| `data-out` | Open diamond, right | `data-in` | Data dependency output |
+
+**Connection validation rules:**
+
+- Control ports connect only to control ports.
+- Data ports connect only to data ports.
+- Self-connections are rejected.
+- Duplicate edges between the same pair of ports are rejected.
+- Cycles in control flow are rejected (except Supervisor, which has
+  an internal loop managed by the runtime).
+
+------------------------------------------------------------------------
+
+## 4. Edge Types
+
+### 4.1 Control Flow Edges
+
+Control flow edges define execution order. They are rendered as solid
+lines with directional arrows.
+
+```typescript
+interface ControlEdge {
+  id: string;
+  type: 'control';
+  source: string;       // source node ID
+  target: string;       // target node ID
+  sourceHandle: string; // e.g., 'control-out' or 'branch-billing'
+  targetHandle: string; // e.g., 'control-in'
+  label?: string;       // e.g., 'approved', 'billing', 'timeout'
+  animated?: boolean;   // pulsing animation during execution
+}
+```
+
+### 4.2 Data Flow Edges
+
+Data flow edges define how output data from one node feeds as input to
+another. They are rendered as dashed lines with diamond arrowheads.
+
+```typescript
+interface DataEdge {
+  id: string;
+  type: 'data';
+  source: string;
+  target: string;
+  sourceHandle: string; // e.g., 'data-out' or 'response'
+  targetHandle: string; // e.g., 'data-in' or 'query'
+  label?: string;       // e.g., 'keywords', 'context'
+  dataMapping?: {
+    sourceField: string; // JSONPath into source output
+    targetField: string; // JSONPath into target input
+  };
+}
+```
+
+### 4.3 Edge Rendering
+
+| State | Style | Description |
+|-------|-------|-------------|
+| Default (control) | Solid, gray, arrow marker | Static control flow |
+| Default (data) | Dashed, green, diamond marker | Static data flow |
+| Hover | Thickened, highlighted | Mouse over edge |
+| Selected | Blue outline, delete button | Click to select |
+| Executing | Animated pulse (blue) | Currently active during execution |
+| Completed | Solid green | Successfully traversed |
+| Error | Solid red, error icon | Execution failed on this edge |
+
+------------------------------------------------------------------------
+
+## 5. Serialization: Canvas to YAML
+
+The editor serializes the visual graph to Arachne's declarative YAML
+format. This is the same format consumed by `arachne weave`.
+
+### 5.1 Serialization Model
+
+```typescript
+interface WorkflowYAML {
+  apiVersion: 'arachne-ai.com/v0';
+  kind: 'Workflow';
+  metadata: {
+    name: string;
+    description?: string;
+    tags?: string[];
+    version?: string;
+  };
+  spec: {
+    trigger: TriggerSpec;
+    steps: StepSpec[];
+    edges: EdgeSpec[];
+  };
+}
+
+interface TriggerSpec {
+  type: 'api' | 'schedule' | 'webhook' | 'channel';
+  // Schedule-specific
+  cron?: string;
+  timezone?: string;
+  // Webhook-specific
+  webhookUrl?: string;
+  // Channel-specific
+  channel?: string;
+  channelPattern?: 'broadcast' | 'directed';
+}
+
+interface StepSpec {
+  id: string;
+  type: NodeType;
+  name: string;
+  config: Record<string, unknown>; // type-specific configuration
+  position: { x: number; y: number }; // preserved for editor round-trip
+}
+
+interface EdgeSpec {
+  from: string;      // step ID
+  to: string;        // step ID
+  type: 'control' | 'data';
+  label?: string;    // branch label for conditional/router
+  dataMapping?: {
+    sourceField: string;
+    targetField: string;
+  };
+}
+```
+
+### 5.2 YAML Output Example
+
+A workflow where a router classifies customer intent, routes to
+specialist agents, and collects results:
+
+```yaml
+apiVersion: arachne-ai.com/v0
+kind: Workflow
+metadata:
+  name: customer-support-workflow
+  description: Routes customer requests to specialist agents
+  tags: [support, routing]
+spec:
+  trigger:
+    type: api
+
+  steps:
+    - id: start
+      type: Start
+      name: Customer Request
+      config: {}
+      position: { x: 100, y: 300 }
+
+    - id: classify
+      type: Router
+      name: Intent Classifier
+      config:
+        routerAgent: triage-agent
+        routes:
+          - intent: billing
+            label: Billing
+          - intent: technical
+            label: Technical
+          - intent: general
+            label: General
+        fallback: general
+      position: { x: 400, y: 300 }
+
+    - id: billing-handler
+      type: LLMCall
+      name: Billing Specialist
+      config:
+        agentRef: billing-agent
+        knowledgeBaseRefs:
+          - company-policies-kb
+      position: { x: 700, y: 100 }
+
+    - id: tech-handler
+      type: LLMCall
+      name: Tech Support
+      config:
+        agentRef: tech-support-agent
+      position: { x: 700, y: 300 }
+
+    - id: general-handler
+      type: LLMCall
+      name: General Support
+      config:
+        agentRef: general-agent
+      position: { x: 700, y: 500 }
+
+    - id: respond
+      type: End
+      name: Send Response
+      config: {}
+      position: { x: 1000, y: 300 }
+
+  edges:
+    - { from: start, to: classify, type: control }
+    - { from: classify, to: billing-handler, type: control, label: billing }
+    - { from: classify, to: tech-handler, type: control, label: technical }
+    - { from: classify, to: general-handler, type: control, label: general }
+    - { from: billing-handler, to: respond, type: control }
+    - { from: tech-handler, to: respond, type: control }
+    - { from: general-handler, to: respond, type: control }
+```
+
+### 5.3 Deserialization (YAML to Canvas)
+
+The editor can import any valid Workflow YAML:
+
+1. Parse YAML and validate against the Workflow JSON Schema.
+2. Map each `StepSpec` to a React Flow node with the corresponding
+   custom component and port configuration.
+3. Map each `EdgeSpec` to a React Flow edge with type-appropriate
+   styling.
+4. Restore node positions from `position` fields (auto-layout if
+   positions are missing).
+5. Populate the Zustand store and trigger a `fitView()`.
+
+### 5.4 Round-Trip Guarantee
+
+The serializer preserves all fields. A workflow loaded from YAML and
+immediately re-serialized produces byte-identical output (modulo
+whitespace normalization). This is enforced by integration tests.
+
+### 5.5 Mapping to Existing Artifact Kinds
+
+When a Workflow YAML is woven, the weave pipeline expands it into
+constituent artifacts:
+
+| Workflow Construct | Produced Artifact(s) |
+|-------------------|---------------------|
+| LLM Call with inline config | `kind: Agent` |
+| LLM Call with `agentRef` | Reference to existing Agent |
+| Router / Handoff / Parallel / Supervisor | `kind: AgentTeam` with corresponding coordination pattern |
+| Memory/RAG with inline config | `kind: KnowledgeBase` |
+| Tool Invocation | Reference to existing ToolPackage |
+| Trigger (schedule) | `schedule` block on the root agent/team |
+| Channel Send/Receive | `channels` block on participating agents |
+| Subflow | Reference to another Workflow artifact |
+
+This means the `kind: Workflow` artifact is a higher-level abstraction
+that compiles down to the existing Agent, AgentTeam, and KnowledgeBase
+primitives. The runtime executes the compiled artifacts, not the
+workflow graph directly.
+
+------------------------------------------------------------------------
+
+## 6. User Interface
+
+### 6.1 Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  [<] Workflows  /  customer-support-workflow  v1.2.0      [Deploy ▾]│
+├────────┬─────────────────────────────────────────────┬───────────────┤
+│        │                                             │               │
+│  Node  │              Canvas                         │   Property    │
+│ Palette│          (React Flow)                       │    Panel      │
+│        │                                             │               │
+│ ──────-│  ┌───────┐    ┌──────────┐    ┌───────┐    │  Node: Router │
+│ Flow   │  │ Start ├───>│  Router  ├───>│  End  │    │  ──────────── │
+│  Start │  └───────┘    └──┬───┬───┘    └───────┘    │  Agent: ...   │
+│  End   │              ┌───┘   └───┐                  │  Routes: ...  │
+│  Branch│              ▼           ▼                  │  Fallback: .. │
+│  Delay │         ┌────────┐  ┌────────┐             │               │
+│ ──────-│         │Billing │  │  Tech  │             │  [Validation] │
+│ Agents │         └────────┘  └────────┘             │  ✓ All routes │
+│  LLM   │                                            │    have agents│
+│  Router│   ┌──────────────┐                         │               │
+│  ...   │   │  Minimap     │                         │               │
+│ ──────-│   └──────────────┘                         │               │
+│ Data   │                                             │               │
+│  RAG   │  [Undo] [Redo] [Zoom+] [Zoom-] [FitView]  │               │
+│  Xform │                                             │               │
+├────────┴─────────────────────────────────────────────┴───────────────┤
+│  Validation: ✓ Valid  │  Nodes: 6  │  Edges: 7  │  Last saved: 2m  │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### 6.2 Node Palette (Left Sidebar)
+
+The palette is organized by category. Nodes are added to the canvas via:
+
+1. **Drag and drop** from the palette onto the canvas.
+2. **Double-click** a palette item to add at the viewport center.
+3. **Context menu** (right-click on canvas) shows a searchable node
+   picker.
+
+Categories match the color coding from section 3.2.
+
+**Search:** A filter input at the top of the palette narrows the
+displayed nodes. Typing "LLM" shows only LLM Call; typing "parallel"
+shows Fan-Out and Fan-In.
+
+### 6.3 Property Panel (Right Sidebar)
+
+When a node is selected, the right panel displays an editable form for
+that node's configuration. The form is type-specific:
+
+**LLM Call properties:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Name | text | Display name on the canvas |
+| Agent | combobox | Select from deployed agents (fetched from `/v1/portal/agents`) or "Inline" |
+| Model | combobox | Model selection (when inline) |
+| System Prompt | textarea | System prompt (when inline) |
+| Temperature | slider (0-2) | LLM temperature |
+| Max Tokens | number | Response token limit |
+| Knowledge Bases | multi-select | Attached KBs (fetched from `/v1/portal/knowledge-bases`) |
+| Tools | multi-select | Attached MCP tools (discovered via tool registry) |
+
+**Router properties:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Router Agent | combobox | Agent that performs classification |
+| Routes | dynamic list | Intent label + target (auto-creates output ports) |
+| Fallback | combobox | Default route when no intent matches |
+
+**Conditional Branch properties:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Condition Type | select | Expression, JSONPath, LLM classifier |
+| Expression | code input | JavaScript expression evaluated against input data |
+| Branches | dynamic list | Label + condition value (auto-creates output ports) |
+| Default Branch | select | Fallback branch |
+
+**Transform properties:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Transform Type | select | JavaScript expression, Handlebars template, JSONPath |
+| Expression | code input | The transformation logic |
+| Input Schema | JSON editor | Expected input shape (optional, for validation) |
+| Output Schema | JSON editor | Output shape (optional, for validation) |
+
+### 6.4 Toolbar
+
+| Button | Shortcut | Action |
+|--------|----------|--------|
+| Undo | `Cmd+Z` | Revert last action |
+| Redo | `Cmd+Shift+Z` | Reapply reverted action |
+| Delete | `Backspace` / `Delete` | Remove selected nodes/edges |
+| Copy | `Cmd+C` | Copy selected nodes |
+| Paste | `Cmd+V` | Paste copied nodes |
+| Select All | `Cmd+A` | Select all nodes and edges |
+| Zoom In | `Cmd+=` | Increase zoom level |
+| Zoom Out | `Cmd+-` | Decrease zoom level |
+| Fit View | `Cmd+0` | Fit all nodes in viewport |
+| Validate | `Cmd+Shift+V` | Run validation checks |
+| Save | `Cmd+S` | Save workflow to server |
+| Export YAML | `Cmd+E` | Download workflow as YAML file |
+| Import YAML | `Cmd+I` | Upload and parse a YAML file |
+
+### 6.5 Canvas Interactions
+
+| Interaction | Behavior |
+|-------------|----------|
+| Pan | Click+drag on background, or scroll wheel |
+| Zoom | Pinch/scroll with Ctrl, or toolbar buttons |
+| Select node | Click on node |
+| Multi-select | Shift+click, or draw selection rectangle |
+| Move node | Drag selected node(s) |
+| Connect | Drag from output port to input port |
+| Disconnect | Click edge, press Delete |
+| Context menu | Right-click on canvas/node/edge |
+| Quick add | Double-click on canvas opens node picker |
+
+### 6.6 Minimap
+
+React Flow's built-in `<MiniMap>` component renders a thumbnail
+overview of the full graph in the bottom-left corner. Nodes are colored
+by category. The viewport rectangle is draggable for quick navigation.
+
+### 6.7 Undo/Redo
+
+The Zustand store uses an immer-based patch system:
+
+1. Every state mutation generates a JSON patch.
+2. Patches are pushed to an undo stack (max 100 entries).
+3. Undo pops the last patch and applies its inverse.
+4. Redo reapplies a popped patch.
+5. Any new mutation after an undo clears the redo stack.
+
+Undo/redo covers: node add/remove/move, edge add/remove, property
+changes, and bulk operations (paste, delete selection).
+
+------------------------------------------------------------------------
+
+## 7. Validation
+
+The editor performs continuous validation and displays errors inline on
+the canvas and in the status bar.
+
+### 7.1 Validation Rules
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| `single-start` | Error | Exactly one Start or Trigger node required |
+| `reachable-end` | Error | Every control flow path must reach an End node |
+| `no-orphans` | Warning | All nodes must be connected to the graph |
+| `no-cycles` | Error | Control flow must be acyclic (except Supervisor internal loop) |
+| `port-type-match` | Error | Control ports connect to control; data to data |
+| `no-duplicate-edges` | Error | At most one edge between any port pair |
+| `fan-out-fan-in-paired` | Error | Every Fan-Out must have a corresponding Fan-In |
+| `agent-ref-exists` | Warning | Referenced agents must exist in the tenant's registry |
+| `kb-ref-exists` | Warning | Referenced KBs must be deployed |
+| `router-has-routes` | Error | Router nodes must have at least one route |
+| `router-has-fallback` | Error | Router nodes must specify a fallback |
+| `conditional-has-branches` | Error | Conditional Branch must have at least 2 branches |
+| `transform-valid-expr` | Error | Transform expressions must parse without syntax errors |
+| `schedule-valid-cron` | Error | Cron expressions must be valid 5-field format |
+| `hitl-has-reviewer` | Warning | HITL nodes should specify a reviewer role or webhook |
+| `subflow-ref-exists` | Warning | Referenced subflow workflows must exist |
+
+### 7.2 Validation Display
+
+- **Inline:** Nodes with validation errors show a red badge with error
+  count. Hovering the badge shows the error messages.
+- **Status bar:** Bottom bar shows overall validation status
+  (valid/invalid) with error/warning counts.
+- **Property panel:** The panel for a selected node highlights fields
+  that have validation errors with red borders and error text.
+- **Pre-save check:** Saving or deploying triggers a full validation
+  pass. Errors block save; warnings allow save with confirmation.
+
+### 7.3 Validation Timing
+
+- **On change:** Lightweight structural checks (connectivity, port
+  types) run on every graph mutation with 300ms debounce.
+- **On save:** Full validation including agent/KB reference resolution
+  (requires API calls).
+- **On deploy:** Server-side validation mirrors the client-side checks
+  plus weave-time validation (same as `arachne weave --dry-run`).
+
+------------------------------------------------------------------------
+
+## 8. Integration with Arachne APIs
+
+### 8.1 Agent Registry
+
+The editor fetches the tenant's deployed agents for LLM Call and Router
+node configuration:
+
+```
+GET /v1/portal/agents → { agents: [{ id, name, model, ... }] }
+```
+
+The agent combobox in the property panel is populated from this endpoint.
+Results are cached client-side with a 60-second TTL and refreshed on
+panel open.
+
+### 8.2 Knowledge Base Registry
+
+```
+GET /v1/portal/knowledge-bases → { knowledgeBases: [{ id, name, ... }] }
+```
+
+The KB multi-select in LLM Call and Memory/RAG nodes uses this endpoint.
+
+### 8.3 MCP Tool Discovery
+
+```
+GET /v1/portal/tools → { tools: [{ name, description, inputSchema, ... }] }
+```
+
+Tool Invocation nodes display discovered MCP tools with their
+descriptions and input schemas. The property panel renders a form
+matching the tool's JSON Schema for static configuration.
+
+### 8.4 Channel Registry
+
+```
+GET /v1/channels → { channels: [{ name, pattern, subscriberCount, ... }] }
+```
+
+Channel Send and Channel Receive nodes use this endpoint to populate
+the channel name selector.
+
+### 8.5 Workflow CRUD
+
+```
+POST   /v1/portal/workflows              # Create workflow
+GET    /v1/portal/workflows              # List workflows
+GET    /v1/portal/workflows/:id          # Get workflow (includes YAML + canvas state)
+PUT    /v1/portal/workflows/:id          # Update workflow
+DELETE /v1/portal/workflows/:id          # Delete workflow
+POST   /v1/portal/workflows/:id/deploy   # Deploy workflow (weave + push + deploy)
+POST   /v1/portal/workflows/:id/validate # Server-side validation
+```
+
+### 8.6 Execution & Trace
+
+```
+POST   /v1/portal/workflows/:id/execute  # Trigger a test execution
+GET    /v1/portal/workflows/:id/executions        # List executions
+GET    /v1/portal/workflows/:id/executions/:runId  # Get execution details (trace tree)
+```
+
+Execution results include per-step trace data (latency, tokens, status,
+ACP messages) that the editor overlays on the canvas.
+
+------------------------------------------------------------------------
+
+## 9. Execution Visualization
+
+### 9.1 Overview
+
+When a workflow is executing or when reviewing a past execution, the
+editor overlays runtime state on the canvas. This transforms the editor
+from an authoring tool into a debugging and monitoring surface.
+
+### 9.2 Node Execution States
+
+| State | Visual | Description |
+|-------|--------|-------------|
+| Idle | Default appearance | Not yet reached by execution |
+| Queued | Subtle pulse border | Scheduled for execution, waiting |
+| Running | Blue animated border | Currently executing |
+| Completed | Green border, check icon | Finished successfully |
+| Error | Red border, error icon | Failed with error |
+| Skipped | Gray, reduced opacity | Not reached (branch not taken) |
+
+### 9.3 Execution Overlay Data
+
+When a node is selected during execution view, the property panel shows
+runtime data:
+
+| Field | Description |
+|-------|-------------|
+| Status | Current execution state |
+| Duration | Wall-clock time for this step |
+| Token Usage | Input + output tokens consumed |
+| Cost | Estimated cost (from analytics cost model) |
+| Input | The data/message received by this node |
+| Output | The data/message produced by this node |
+| ACP Messages | Raw ACP wire-format messages sent/received |
+| Error | Error message and stack trace (if failed) |
+| Model | LLM model used (for LLM Call nodes) |
+| Budget | Allocated vs consumed budget |
+
+### 9.4 Edge Animation
+
+During execution, control flow edges animate with a traveling pulse to
+show the active execution path. Completed edges turn green; error edges
+turn red.
+
+Data flow edges show a brief flash when data is transferred between
+nodes.
+
+### 9.5 Live Execution Mode
+
+For long-running workflows (e.g., supervisor loops), the editor
+supports a live mode:
+
+1. Client opens an SSE connection to
+   `GET /v1/portal/workflows/:id/executions/:runId/stream`.
+2. Server pushes `execution.step.started`, `execution.step.completed`,
+   `execution.step.failed` events.
+3. The editor applies each event to the execution overlay in real time.
+4. The minimap shows execution progress across the full graph.
+
+### 9.6 Trace Tree Panel
+
+A collapsible bottom panel (similar to browser DevTools) shows the
+execution trace as a tree:
+
+```
+▼ customer-support-workflow  (runId: abc123)  2.4s  $0.003
+  ▼ Start: Customer Request  12ms
+  ▼ Router: Intent Classifier  340ms  1,200 tokens
+    ├── ACP: delegate (orch → triage)  m:1
+    └── ACP: report (triage → orch)   m:2  intent=billing
+  ▼ LLM Call: Billing Specialist  1,800ms  3,400 tokens
+    ├── RAG retrieval: company-policies-kb  85ms  3 chunks
+    ├── ACP: delegate (orch → billing)  m:3
+    └── ACP: report (billing → orch)   m:4
+  ▼ End: Send Response  15ms
+```
+
+Clicking a trace row highlights the corresponding node on the canvas
+and scrolls it into view.
+
+------------------------------------------------------------------------
+
+## 10. Database Schema
+
+### 10.1 Workflows Table
+
+```sql
+CREATE TABLE workflows (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id     UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  name          VARCHAR(256) NOT NULL,
+  description   TEXT,
+  tags          JSONB NOT NULL DEFAULT '[]',
+  version       VARCHAR(64) NOT NULL DEFAULT '0.1.0',
+
+  -- Serialized workflow definition
+  spec_yaml     TEXT NOT NULL,            -- The canonical YAML source
+  canvas_state  JSONB NOT NULL,           -- React Flow node positions, viewport, zoom
+
+  -- Deployment tracking
+  deployed_at       TIMESTAMPTZ,
+  deployment_id     UUID REFERENCES deployments(id) ON DELETE SET NULL,
+  last_execution_at TIMESTAMPTZ,
+
+  -- Metadata
+  status        VARCHAR(16) NOT NULL DEFAULT 'draft'
+                CHECK (status IN ('draft', 'deployed', 'archived')),
+  created_by    UUID REFERENCES users(id),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  UNIQUE (tenant_id, name)
+);
+
+CREATE INDEX idx_workflows_tenant ON workflows(tenant_id);
+CREATE INDEX idx_workflows_status ON workflows(tenant_id, status);
+```
+
+### 10.2 Workflow Executions Table
+
+```sql
+CREATE TABLE workflow_executions (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workflow_id   UUID NOT NULL REFERENCES workflows(id) ON DELETE CASCADE,
+  tenant_id     UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+
+  -- Execution state
+  status        VARCHAR(16) NOT NULL DEFAULT 'running'
+                CHECK (status IN ('running', 'completed', 'failed', 'cancelled')),
+  trigger_type  VARCHAR(16) NOT NULL DEFAULT 'manual'
+                CHECK (trigger_type IN ('manual', 'api', 'schedule', 'webhook', 'channel')),
+
+  -- Input / output
+  input         JSONB,
+  output        JSONB,
+  error         TEXT,
+
+  -- Trace linkage
+  trace_id      UUID,                     -- Links to the top-level Trace row
+  correlation_id VARCHAR(32),             -- ACP correlation ID
+
+  -- Timing
+  started_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at  TIMESTAMPTZ,
+  duration_ms   INTEGER,
+
+  -- Cost
+  total_tokens  INTEGER DEFAULT 0,
+  total_cost_cents NUMERIC(10,4) DEFAULT 0
+);
+
+CREATE INDEX idx_wf_exec_workflow ON workflow_executions(workflow_id);
+CREATE INDEX idx_wf_exec_tenant ON workflow_executions(tenant_id);
+CREATE INDEX idx_wf_exec_status ON workflow_executions(tenant_id, status);
+```
+
+### 10.3 Workflow Step Executions Table
+
+```sql
+CREATE TABLE workflow_step_executions (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  execution_id    UUID NOT NULL REFERENCES workflow_executions(id) ON DELETE CASCADE,
+  step_id         VARCHAR(128) NOT NULL,   -- Matches step.id in the workflow spec
+
+  -- Execution state
+  status          VARCHAR(16) NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending', 'queued', 'running', 'completed',
+                                     'failed', 'skipped')),
+
+  -- Data
+  input           JSONB,
+  output          JSONB,
+  error           TEXT,
+
+  -- Trace linkage
+  trace_id        UUID,                    -- Links to the sub-agent Trace row
+  acp_messages    JSONB,                   -- Array of ACP messages for this step
+
+  -- Timing
+  started_at      TIMESTAMPTZ,
+  completed_at    TIMESTAMPTZ,
+  duration_ms     INTEGER,
+
+  -- Cost
+  tokens_used     INTEGER DEFAULT 0,
+  cost_cents      NUMERIC(10,4) DEFAULT 0
+);
+
+CREATE INDEX idx_wf_step_exec ON workflow_step_executions(execution_id);
+CREATE INDEX idx_wf_step_status ON workflow_step_executions(execution_id, status);
+```
+
+### 10.4 Encryption
+
+- `spec_yaml` and `canvas_state` are encrypted at rest using the
+  per-tenant AES-256-GCM key derivation (same pattern as traces and
+  conversation messages).
+- `workflow_step_executions.input`, `output`, and `acp_messages` are
+  encrypted with the same per-tenant key.
+- Encryption/decryption happens in the application layer (service), not
+  in the database.
+
+### 10.5 Entity Schema (MikroORM)
+
+```typescript
+// src/domain/entities/Workflow.ts
+
+class Workflow {
+  id: string;
+  tenantId: string;
+  name: string;
+  description: string | null;
+  tags: string[];
+  version: string;
+  specYaml: string;
+  canvasState: Record<string, unknown>;
+  deployedAt: Date | null;
+  deploymentId: string | null;
+  lastExecutionAt: Date | null;
+  status: 'draft' | 'deployed' | 'archived';
+  createdBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export const WorkflowSchema = new EntitySchema<Workflow>({
+  class: Workflow,
+  tableName: 'workflows',
+  properties: {
+    id:              { type: 'uuid', primary: true },
+    tenantId:        { type: 'uuid', fieldName: 'tenant_id' },
+    name:            { type: 'string', length: 256 },
+    description:     { type: 'string', nullable: true },
+    tags:            { type: 'json', default: '[]' },
+    version:         { type: 'string', length: 64, default: '0.1.0' },
+    specYaml:        { type: 'text', fieldName: 'spec_yaml' },
+    canvasState:     { type: 'json', fieldName: 'canvas_state' },
+    deployedAt:      { type: 'datetime', nullable: true, fieldName: 'deployed_at' },
+    deploymentId:    { type: 'uuid', nullable: true, fieldName: 'deployment_id' },
+    lastExecutionAt: { type: 'datetime', nullable: true, fieldName: 'last_execution_at' },
+    status:          { type: 'string', length: 16, default: 'draft' },
+    createdBy:       { type: 'uuid', nullable: true, fieldName: 'created_by' },
+    createdAt:       { type: 'datetime', fieldName: 'created_at' },
+    updatedAt:       { type: 'datetime', fieldName: 'updated_at' },
+  },
+  uniques: [{ properties: ['tenantId', 'name'] }],
+});
+```
+
+------------------------------------------------------------------------
+
+## 11. Portal UI Integration
+
+### 11.1 Route Structure
+
+The workflow editor is embedded within the existing Portal SPA:
+
+```
+/workflows                    → Workflow list page
+/workflows/new                → New workflow (empty canvas)
+/workflows/:id                → Edit existing workflow
+/workflows/:id/executions     → Execution history
+/workflows/:id/executions/:runId → Execution detail (trace overlay)
+```
+
+### 11.2 Navigation
+
+The Portal's sidebar navigation gains a new "Workflows" entry:
+
+```
+├── Dashboard
+├── Agents
+├── Knowledge Bases
+├── Workflows            ← NEW
+│   ├── All Workflows
+│   └── New Workflow
+├── API Keys
+├── Analytics
+└── Settings
+```
+
+### 11.3 Workflow List Page
+
+A table view showing all workflows for the current tenant:
+
+| Column | Description |
+|--------|-------------|
+| Name | Workflow name (link to editor) |
+| Status | Draft / Deployed / Archived |
+| Version | Semantic version string |
+| Nodes | Node count |
+| Last Modified | Timestamp |
+| Last Executed | Timestamp (if ever executed) |
+| Actions | Edit, Duplicate, Delete, Deploy/Undeploy |
+
+Filters: status, tags. Search: name substring match.
+
+### 11.4 Component Architecture
+
+```
+portal/src/
+  pages/
+    WorkflowListPage.tsx          # List view
+    WorkflowEditorPage.tsx        # Main editor page (hosts canvas)
+    WorkflowExecutionPage.tsx     # Execution detail with trace overlay
+  components/
+    workflow/
+      Canvas.tsx                  # React Flow wrapper
+      NodePalette.tsx             # Left sidebar with node categories
+      PropertyPanel.tsx           # Right sidebar with node config form
+      Toolbar.tsx                 # Top toolbar (undo, zoom, etc.)
+      ExecutionOverlay.tsx        # Execution state visualization
+      TraceTreePanel.tsx          # Bottom panel for trace inspection
+      ValidationBadge.tsx         # Inline node validation indicator
+      nodes/                     # Custom React Flow node components
+        StartNode.tsx
+        EndNode.tsx
+        LLMCallNode.tsx
+        ToolInvocationNode.tsx
+        ConditionalBranchNode.tsx
+        RouterNode.tsx
+        HandoffNode.tsx
+        FanOutNode.tsx
+        FanInNode.tsx
+        SupervisorNode.tsx
+        HITLNode.tsx
+        MemoryRAGNode.tsx
+        TransformNode.tsx
+        SubflowNode.tsx
+        TriggerNode.tsx
+        ChannelSendNode.tsx
+        ChannelReceiveNode.tsx
+        DelayNode.tsx
+      edges/
+        ControlEdge.tsx           # Solid arrow edge
+        DataEdge.tsx              # Dashed diamond edge
+      panels/
+        LLMCallPanel.tsx          # Property panel for LLM Call
+        RouterPanel.tsx           # Property panel for Router
+        ConditionalPanel.tsx      # Property panel for Conditional
+        TransformPanel.tsx        # Property panel for Transform
+        ... (one per node type)
+  stores/
+    workflowEditorStore.ts        # Zustand store
+  lib/
+    workflowSerializer.ts         # Canvas ↔ YAML conversion
+    workflowValidator.ts          # Client-side validation engine
+    workflowApi.ts                # API client for workflow endpoints
+```
+
+### 11.5 Dependencies
+
+Added to the Portal's `package.json`:
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `@xyflow/react` | `^12.x` | Core graph editor |
+| `yaml` | `^2.x` | YAML parse/stringify (already available) |
+| `elkjs` | `^0.9.x` | Auto-layout engine (ELK algorithm) |
+| `immer` | `^10.x` | Immutable state patches for undo/redo |
+
+All other dependencies (React, Zustand, Tailwind, Recharts) are already
+in the Portal.
+
+------------------------------------------------------------------------
+
+## 12. Auto-Layout
+
+When importing YAML without position data, or when the user requests
+automatic arrangement, the editor uses the **ELK** (Eclipse Layout
+Kernel) algorithm via `elkjs`:
+
+### 12.1 Layout Algorithm
+
+```typescript
+import ELK from 'elkjs/lib/elk.bundled.js';
+
+const elk = new ELK();
+
+async function autoLayout(nodes: Node[], edges: Edge[]): Promise<Node[]> {
+  const graph = {
+    id: 'root',
+    layoutOptions: {
+      'elk.algorithm': 'layered',
+      'elk.direction': 'RIGHT',
+      'elk.spacing.nodeNode': '80',
+      'elk.layered.spacing.nodeNodeBetweenLayers': '120',
+      'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
+    },
+    children: nodes.map((n) => ({
+      id: n.id,
+      width: n.measured?.width ?? 240,
+      height: n.measured?.height ?? 120,
+    })),
+    edges: edges.map((e) => ({
+      id: e.id,
+      sources: [e.source],
+      targets: [e.target],
+    })),
+  };
+
+  const layout = await elk.layout(graph);
+
+  return nodes.map((node) => {
+    const laid = layout.children?.find((c) => c.id === node.id);
+    return laid
+      ? { ...node, position: { x: laid.x ?? 0, y: laid.y ?? 0 } }
+      : node;
+  });
+}
+```
+
+### 12.2 Layout Triggers
+
+- **Import YAML:** Auto-layout applied if any node lacks position data.
+- **Manual:** "Auto-arrange" button in toolbar (`Cmd+Shift+A`).
+- **Partial:** Select a subset of nodes and auto-arrange only those.
+
+------------------------------------------------------------------------
+
+## 13. Security Considerations
+
+1. **Tenant isolation:** All workflow endpoints filter by `tenant_id`
+   from the authenticated JWT context. Cross-tenant workflow access is
+   not possible.
+
+2. **Transform node sandboxing:** JavaScript expressions in Transform
+   nodes execute in a sandboxed context (no access to `globalThis`,
+   `process`, `require`, `fetch`, or filesystem). The sandbox uses a
+   restricted function constructor with a whitelist of safe globals
+   (`JSON`, `Math`, `Date`, `String`, `Number`, `Array`, `Object`).
+
+3. **Encryption at rest:** Workflow specs, canvas state, and execution
+   data are encrypted using per-tenant AES-256-GCM keys (same pattern
+   as traces and conversations).
+
+4. **Deploy authorization:** Only users with `admin` or `editor` role
+   in the tenant can deploy workflows. `viewer` role can view and run
+   test executions but cannot modify or deploy.
+
+5. **Subflow reference resolution:** Subflow references are resolved
+   within the same tenant. Cross-tenant subflow references are not
+   permitted.
+
+6. **YAML import validation:** Imported YAML is validated against a
+   strict JSON Schema before deserialization. Malformed or
+   unrecognized fields are rejected with descriptive errors.
+
+7. **Execution cost limits:** Test executions respect the tenant's
+   configured token/cost budgets. Budget propagation through ACP
+   ensures no single test run can exhaust tenant resources.
+
+------------------------------------------------------------------------
+
+## 14. Accessibility
+
+The workflow editor follows WAI-ARIA patterns where applicable within
+a canvas-based interface:
+
+| Feature | Implementation |
+|---------|---------------|
+| Keyboard navigation | Tab between nodes, Enter to select, arrow keys to move |
+| Screen reader labels | ARIA labels on all nodes, edges, and toolbar buttons |
+| Focus indicators | Visible focus ring on selected nodes and controls |
+| Palette keyboard access | Arrow keys to navigate categories, Enter to add node |
+| High contrast | Respects system-level high-contrast preference |
+| Reduced motion | Disables edge animations when `prefers-reduced-motion` is set |
+
+------------------------------------------------------------------------
+
+## 15. Phase Plan
+
+### Phase 1: Core Editor (MVP)
+
+**Scope:**
+- Canvas with Start, End, LLM Call, Conditional Branch, Transform nodes
+- Control flow edges only (no data edges)
+- Node palette (drag and drop)
+- Property panel for all Phase 1 node types
+- YAML serialization and deserialization (round-trip fidelity)
+- Import/export YAML files
+- Client-side validation (structural rules)
+- Undo/redo (50-level stack)
+- Minimap and zoom controls
+- Workflow CRUD API and database schema
+- Workflow list page in Portal
+
+**Milestone:** Users can visually build simple sequential and branching
+agent workflows and export valid YAML.
+
+### Phase 2: Multi-Agent Patterns
+
+**Scope:**
+- Router, Handoff, Parallel (Fan-Out/Fan-In), Supervisor nodes
+- Data flow edges with data mapping configuration
+- Agent registry integration (combobox population)
+- KB registry integration (Memory/RAG node)
+- Auto-layout (ELK)
+- Server-side validation (weave dry-run)
+- Deploy from editor (one-click weave + push + deploy)
+
+**Milestone:** Full coverage of AgentTeam coordination patterns.
+Users can deploy multi-agent workflows directly from the editor.
+
+### Phase 3: Execution & Debugging
+
+**Scope:**
+- Test execution from editor
+- Execution overlay (node states, edge animation)
+- Trace tree panel
+- Live execution mode (SSE streaming)
+- Execution history page
+- Per-step token/cost breakdown
+
+**Milestone:** End-to-end workflow lifecycle: build, deploy, execute,
+debug -- all within the editor.
+
+### Phase 4: Advanced Nodes & Polish
+
+**Scope:**
+- Tool Invocation node (MCP tool discovery)
+- HITL node (approval gate UI)
+- Channel Send/Receive nodes
+- Subflow node (workflow composition)
+- Trigger node (schedule, webhook, channel)
+- Delay node
+- Copy/paste node groups
+- Keyboard shortcuts for all actions
+- Accessibility audit and fixes
+- Performance optimization for 100+ node workflows
+
+**Milestone:** Feature-complete workflow editor with all node types.
+
+### Phase 5: Collaboration & History (Future)
+
+**Scope:**
+- Workflow version history (diff view)
+- Workflow templates / marketplace
+- Collaborative editing (multiplayer)
+- Workflow-level analytics dashboard
+- Custom node types via plugin system
+
+------------------------------------------------------------------------
+
+## 16. Comparison with Existing Tools
+
+### 16.1 Langflow
+
+Langflow is an open-source visual framework for LangChain workflows.
+Key differences from Arachne's editor:
+
+| Aspect | Langflow | Arachne Workflow Editor |
+|--------|----------|------------------------|
+| Runtime | LangChain (Python) | Arachne (Node.js/TypeScript) |
+| Artifact model | Standalone flows | Compiles to Agent/AgentTeam YAML artifacts |
+| Multi-agent patterns | Ad hoc node wiring | First-class Router/Handoff/Parallel/Supervisor nodes |
+| Protocol | REST between components | ACP wire protocol with budget propagation |
+| Execution tracing | Basic logging | Full ACP trace DAG with cost tracking |
+| Deployment | Docker container per flow | Standard Arachne weave/push/deploy pipeline |
+| Multi-tenancy | None | Native tenant isolation, encrypted at rest |
+
+### 16.2 Dify
+
+Dify provides a visual orchestration layer with a canvas editor. Key
+differences:
+
+| Aspect | Dify | Arachne Workflow Editor |
+|--------|------|------------------------|
+| Agent model | Built-in agent types | Custom agents via YAML specs |
+| Knowledge management | Built-in KB | Arachne KnowledgeBase artifacts with RAG |
+| Channel messaging | Not supported | Native AgentBus channels |
+| Cost governance | Token tracking only | ACP budget propagation (tokens, cost, TTL) |
+| CLI/IaC | GUI-only | Bidirectional YAML round-trip; CLI-first |
+| Scheduling | Basic cron | Declarative schedules with retry policies |
+
+### 16.3 Design Principles from Prior Art
+
+Patterns adopted from Langflow/Dify that inform the Arachne editor:
+
+1. **Drag-and-drop palette** with categorized node types.
+2. **Right-panel property editor** that adapts to selected node type.
+3. **Real-time validation** with inline error badges.
+4. **Minimap** for navigation in complex workflows.
+5. **One-click test execution** with result overlay.
+
+Patterns we deliberately diverge from:
+
+1. **No embedded code editor.** Arachne agents are configured
+   declaratively, not programmed. Transform nodes support expressions
+   but not arbitrary scripts.
+2. **YAML is the source of truth,** not a database-only representation.
+   Workflows are portable, version-controllable, and CLI-compatible.
+3. **Multi-agent patterns are first-class nodes,** not emergent
+   properties of arbitrary wiring. A Router node is semantically
+   distinct from manually connecting an LLM node to a conditional
+   branch, because the runtime optimizes for the pattern.
+
+------------------------------------------------------------------------
+
+## 17. Open Questions
+
+1. **Workflow versioning model.** Should workflow versions follow
+   semantic versioning (manual bump) or auto-increment on save?
+   Recommendation: semver with manual bump, matching agent versioning.
+
+2. **Subflow depth limit.** Should there be a maximum nesting depth
+   for subflow references to prevent runaway compilation? Proposed
+   limit: 5 levels.
+
+3. **Transform node language.** Should transforms support only
+   JavaScript expressions, or also JSONata / JMESPath? Proposal: start
+   with JavaScript expressions only; add JSONata in Phase 4 if demand
+   exists.
+
+4. **HITL webhook vs. Portal UI.** Should HITL approval flow through a
+   dedicated Portal page, a webhook to an external system, or both?
+   Recommendation: Portal page for MVP, webhook for Phase 4.
+
+5. **Collaborative editing priority.** Is real-time collaboration
+   (Phase 5) a near-term need for the target customer, or is it
+   deferred indefinitely? Depends on go-to-market feedback.
+
+------------------------------------------------------------------------
+
+## Summary
+
+The Workflow Editor introduces a visual authoring surface for Arachne's
+multi-agent workflows, built on React Flow within the existing Portal
+SPA. It provides drag-and-drop workflow construction, bidirectional YAML
+serialization, integration with Arachne's agent/KB/tool registries, and
+execution visualization powered by ACP trace data. The five-phase
+delivery plan starts with a core canvas for simple workflows and
+progressively adds multi-agent patterns, execution debugging, advanced
+node types, and collaboration features. The editor complements -- but
+does not replace -- the CLI-first YAML workflow, ensuring that all
+workflows remain portable, version-controllable, and deployable through
+the standard `arachne weave` pipeline.


### PR DESCRIPTION
## Summary

Adds eight specification documents that were drafted in April 2026 and left untracked on `develop`. No code changes.

| File | Description |
|------|-------------|
| `docs/gcp_migration_spec.md` | Azure → GCP infrastructure migration plan |
| `docs/system_specs/agui_adoption_spec.md` | AG-UI protocol adoption for runtime and portal chat |
| `docs/system_specs/arachne_v2_tool_transport_spec.md` | stdio / HTTP / platform tool transport models |
| `docs/system_specs/beta_signup_enrichment_spec.md` | Beta signup data enrichment pipeline |
| `docs/system_specs/goose_extraction_spec.md` | Goose agent extraction and integration |
| `docs/system_specs/oas_arachne_mapping.md` | OpenAPI Specification → Arachne entity mapping |
| `docs/system_specs/oas_gap_analysis.md` | Gap analysis between OAS and current schema |
| `docs/system_specs/workflow_editor_spec.md` | Visual workflow editor feature specification |

🤖 Generated with [Claude Code](https://claude.com/claude-code)